### PR TITLE
Querier/execute logicalplan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [FEATURE] Distributor/Ingester: Implemented experimental feature to use gRPC stream connection for push requests. This can be enabled by setting `-distributor.use-stream-push=true`. #6580
 * [FEATURE] Compactor: Add support for percentage based sharding for compactors. #6738
 * [FEATURE] Querier: Allow choosing PromQL engine via header. #6777
+* [FEATURE] Querier: Support for configuring query optimizers and enabling XFunctions in the Thanos engine. #6873
 * [ENHANCEMENT] Tenant Federation: Add a # of query result limit logic when the `-tenant-federation.regex-matcher-enabled` is enabled. #6845
 * [ENHANCEMENT] Query Frontend: Add a `cortex_slow_queries_total` metric to track # of slow queries per user. #6859
 * [ENHANCEMENT] Query Frontend: Change to return 400 when the tenant resolving fail. #6715

--- a/Makefile
+++ b/Makefile
@@ -87,15 +87,12 @@ $(foreach exe, $(EXES), $(eval $(call dep_exe, $(exe))))
 pkg/cortexpb/cortex.pb.go: pkg/cortexpb/cortex.proto
 pkg/ingester/client/ingester.pb.go: pkg/ingester/client/ingester.proto
 pkg/distributor/distributorpb/distributor.pb.go: pkg/distributor/distributorpb/distributor.proto
-pkg/ingester/wal.pb.go: pkg/ingester/wal.proto
 pkg/ring/ring.pb.go: pkg/ring/ring.proto
 pkg/frontend/v1/frontendv1pb/frontend.pb.go: pkg/frontend/v1/frontendv1pb/frontend.proto
 pkg/frontend/v2/frontendv2pb/frontend.pb.go: pkg/frontend/v2/frontendv2pb/frontend.proto
 pkg/querier/tripperware/queryrange/queryrange.pb.go: pkg/querier/tripperware/queryrange/queryrange.proto
-pkg/querier/tripperware/instantquery/instantquery.pb.go: pkg/querier/tripperware/instantquery/instantquery.proto
 pkg/querier/tripperware/query.pb.go: pkg/querier/tripperware/query.proto
 pkg/querier/stats/stats.pb.go: pkg/querier/stats/stats.proto
-pkg/distributor/ha_tracker.pb.go: pkg/distributor/ha_tracker.proto
 pkg/ruler/rulespb/rules.pb.go: pkg/ruler/rulespb/rules.proto
 pkg/ruler/ruler.pb.go: pkg/ruler/ruler.proto
 pkg/ring/kv/memberlist/kv.pb.go: pkg/ring/kv/memberlist/kv.proto

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 
 # Cortex
 
-Cortex is a horizontally scalable, highly available, multi-tenant, long term storage solution for [Prometheus](https://prometheus.io) and [OpenTelemetry Metrics](https://opentelemetry.io/docs/specs/otel/metrics/)
+Cortex is a horizontally scalable, highly available, multi-tenant, long-term storage solution for [Prometheus](https://prometheus.io) and [OpenTelemetry Metrics](https://opentelemetry.io/docs/specs/otel/metrics/).
 
 ## Features
 
 - **Horizontally scalable:** Cortex can run across multiple machines in a cluster, exceeding the throughput and storage of a single machine.
 - **Highly available:** When run in a cluster, Cortex can replicate data between machines.
 - **Multi-tenant:** Cortex can isolate data and queries from multiple different independent Prometheus sources in a single cluster.
-- **Long term storage:** Cortex supports S3, GCS, Swift and Microsoft Azure for long term storage of metric data.
+- **Long-term storage:** Cortex supports S3, GCS, Swift and Microsoft Azure for long-term storage of metric data.
 
 ## Documentation
 
@@ -76,13 +76,13 @@ Join us in shaping the future of Cortex, and let's build something amazing toget
 - Sep 2020 KubeCon talk "Scaling Prometheus: How We Got Some Thanos Into Cortex" ([video](https://www.youtube.com/watch?v=Z5OJzRogAS4), [slides](https://static.sched.com/hosted_files/kccnceu20/ec/2020-08%20-%20KubeCon%20EU%20-%20Cortex%20blocks%20storage.pdf))
 - Jul 2020 PromCon talk "Sharing is Caring: Leveraging Open Source to Improve Cortex & Thanos" ([video](https://www.youtube.com/watch?v=2oTLouUvsac), [slides](https://docs.google.com/presentation/d/1OuKYD7-k9Grb7unppYycdmVGWN0Bo0UwdJRySOoPdpg/edit))
 - Nov 2019 KubeCon talks "[Cortex 101: Horizontally Scalable Long Term Storage for Prometheus][kubecon-cortex-101]" ([video][kubecon-cortex-101-video], [slides][kubecon-cortex-101-slides]), "[Configuring Cortex for Max
-  Performance][kubecon-cortex-201]" ([video][kubecon-cortex-201-video], [slides][kubecon-cortex-201-slides], [write up][kubecon-cortex-201-writeup]) and "[Blazin’ Fast PromQL][kubecon-blazin]" ([slides][kubecon-blazin-slides], [video][kubecon-blazin-video], [write up][kubecon-blazin-writeup])
+  Performance][kubecon-cortex-201]" ([video][kubecon-cortex-201-video], [slides][kubecon-cortex-201-slides], [write up][kubecon-cortex-201-writeup]) and "[Blazin' Fast PromQL][kubecon-blazin]" ([slides][kubecon-blazin-slides], [video][kubecon-blazin-video], [write up][kubecon-blazin-writeup])
 - Nov 2019 PromCon talk "[Two Households, Both Alike in Dignity: Cortex and Thanos][promcon-two-households]" ([video][promcon-two-households-video], [slides][promcon-two-households-slides], [write up][promcon-two-households-writeup])
 - May 2019 KubeCon talks; "[Cortex: Intro][kubecon-cortex-intro]" ([video][kubecon-cortex-intro-video], [slides][kubecon-cortex-intro-slides], [blog post][kubecon-cortex-intro-blog]) and "[Cortex: Deep Dive][kubecon-cortex-deepdive]" ([video][kubecon-cortex-deepdive-video], [slides][kubecon-cortex-deepdive-slides])
 - Nov 2018 CloudNative London meetup talk; "Cortex: Horizontally Scalable, Highly Available Prometheus" ([slides][cloudnative-london-2018-slides])
 - Aug 2018 PromCon panel; "[Prometheus Long-Term Storage Approaches][promcon-2018-panel]" ([video][promcon-2018-video])
 - Dec 2018 KubeCon talk; "[Cortex: Infinitely Scalable Prometheus][kubecon-2018-talk]" ([video][kubecon-2018-video], [slides][kubecon-2018-slides])
-- Aug 2017 PromCon talk; "[Cortex: Prometheus as a Service, One Year On][promcon-2017-talk]" ([videos][promcon-2017-video], [slides][promcon-2017-slides], write up [part 1][promcon-2017-writeup-1], [part 2][promcon-2017-writeup-2], [part 3][promcon-2017-writeup-3])
+- Aug 2017 PromCon talk; "[Cortex: Prometheus as a Service, One Year On][promcon-2017-talk]" ([video][promcon-2017-video], [slides][promcon-2017-slides], write up [part 1][promcon-2017-writeup-1], [part 2][promcon-2017-writeup-2], [part 3][promcon-2017-writeup-3])
 - Jun 2017 Prometheus London meetup talk; "Cortex: open-source, horizontally-scalable, distributed Prometheus" ([video][prometheus-london-2017-video])
 - Dec 2016 KubeCon talk; "Weave Cortex: Multi-tenant, horizontally scalable Prometheus as a Service" ([video][kubecon-2016-video], [slides][kubecon-2016-slides])
 - Aug 2016 PromCon talk; "Project Frankenstein: Multitenant, Scale-Out Prometheus": ([video][promcon-2016-video], [slides][promcon-2016-slides])
@@ -90,10 +90,10 @@ Join us in shaping the future of Cortex, and let's build something amazing toget
 ### Blog Posts
 
 - Dec 2020 blog post "[How AWS and Grafana Labs are scaling Cortex for the cloud](https://aws.amazon.com/blogs/opensource/how-aws-and-grafana-labs-are-scaling-cortex-for-the-cloud/)"
-- Oct 2020 blog post "[How to switch Cortex from chunks to blocks storage (and why you won’t look back)](https://grafana.com/blog/2020/10/19/how-to-switch-cortex-from-chunks-to-blocks-storage-and-why-you-wont-look-back/)"
+- Oct 2020 blog post "[How to switch Cortex from chunks to blocks storage (and why you won't look back)](https://grafana.com/blog/2020/10/19/how-to-switch-cortex-from-chunks-to-blocks-storage-and-why-you-wont-look-back/)"
 - Oct 2020 blog post "[Now GA: Cortex blocks storage for running Prometheus at scale with reduced operational complexity](https://grafana.com/blog/2020/10/06/now-ga-cortex-blocks-storage-for-running-prometheus-at-scale-with-reduced-operational-complexity/)"
 - Sep 2020 blog post "[A Tale of Tail Latencies](https://www.weave.works/blog/a-tale-of-tail-latencies)"
-- Aug 2020 blog post "[Scaling Prometheus: How we’re pushing Cortex blocks storage to its limit and beyond](https://grafana.com/blog/2020/08/12/scaling-prometheus-how-were-pushing-cortex-blocks-storage-to-its-limit-and-beyond/)"
+- Aug 2020 blog post "[Scaling Prometheus: How we're pushing Cortex blocks storage to its limit and beyond](https://grafana.com/blog/2020/08/12/scaling-prometheus-how-were-pushing-cortex-blocks-storage-to-its-limit-and-beyond/)"
 - Jul 2020 blog post "[How blocks storage in Cortex reduces operational complexity for running Prometheus at massive scale](https://grafana.com/blog/2020/07/29/how-blocks-storage-in-cortex-reduces-operational-complexity-for-running-prometheus-at-massive-scale/)"
 - Mar 2020 blog post "[Cortex: Zone Aware Replication](https://kenhaines.net/cortex-zone-aware-replication/)"
 - Mar 2020 blog post "[How we're using gossip to improve Cortex and Loki availability](https://grafana.com/blog/2020/03/25/how-were-using-gossip-to-improve-cortex-and-loki-availability/)"
@@ -157,7 +157,7 @@ Join us in shaping the future of Cortex, and let's build something amazing toget
 
 ### Amazon Managed Service for Prometheus (AMP)
 
-[Amazon Managed Service for Prometheus (AMP)](https://aws.amazon.com/prometheus/) is a Prometheus-compatible monitoring service that makes it easy to monitor containerized applications at scale. It is a highly available, secure, and managed monitoring for your containers. Get started [here](https://console.aws.amazon.com/prometheus/home). To learn more about the AMP, reference our [documentation](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html) and [Getting Started with AMP blog](https://aws.amazon.com/blogs/mt/getting-started-amazon-managed-service-for-prometheus/).
+[Amazon Managed Service for Prometheus (AMP)](https://aws.amazon.com/prometheus/) is a Prometheus-compatible monitoring service that makes it easy to monitor containerized applications at scale. It is a highly available, secure, and managed monitoring service for your containers. Get started [here](https://console.aws.amazon.com/prometheus/home). To learn more about AMP, reference our [documentation](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html) and [Getting Started with AMP blog](https://aws.amazon.com/blogs/mt/getting-started-amazon-managed-service-for-prometheus/).
 
 ## Emeritus Maintainers
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,9 +21,9 @@ Incoming samples (writes from Prometheus) are handled by the [distributor](#dist
 
 ## Blocks storage
 
-The blocks storage is based on [Prometheus TSDB](https://prometheus.io/docs/prometheus/latest/storage/): it stores each tenant's time series into their own TSDB which write out their series to a on-disk Block (defaults to 2h block range periods). Each Block is composed by a few files storing the chunks and the block index.
+The blocks storage is based on [Prometheus TSDB](https://prometheus.io/docs/prometheus/latest/storage/): it stores each tenant's time series into their own TSDB which writes out their series to an on-disk Block (defaults to 2h block range periods). Each Block is composed of a few files storing the chunks and the block index.
 
-The TSDB chunk files contain the samples for multiple series. The series inside the Chunks are then indexed by a per-block index, which indexes metric names and labels to time series in the chunk files.
+The TSDB chunk files contain the samples for multiple series. The series inside the chunks are then indexed by a per-block index, which indexes metric names and labels to time series in the chunk files.
 
 The blocks storage doesn't require a dedicated storage backend for the index. The only requirement is an object store for the Block files, which can be:
 
@@ -60,7 +60,7 @@ The **distributor** service is responsible for handling incoming samples from Pr
 
 The validation done by the distributor includes:
 
-- The metric labels name are formally correct
+- The metric label names are formally correct
 - The configured max number of labels per metric is respected
 - The configured max length of a label name and value is respected
 - The timestamp is not older/newer than the configured min/max time range
@@ -80,7 +80,7 @@ The supported KV stores for the HA tracker are:
 * [Consul](https://www.consul.io)
 * [Etcd](https://etcd.io)
 
-Note: Memberlist is not supported. Memberlist-based KV store propagates updates using gossip, which is very slow for HA purposes: result is that different distributors may see different Prometheus server as elected HA replica, which is definitely not desirable.
+Note: Memberlist is not supported. Memberlist-based KV store propagates updates using gossip, which is very slow for HA purposes: the result is that different distributors may see different Prometheus servers as the elected HA replica, which is definitely not desirable.
 
 For more information, please refer to [config for sending HA pairs data to Cortex](guides/ha-pair-handling.md) in the documentation.
 
@@ -97,11 +97,11 @@ The trade-off associated with the latter is that writes are more balanced across
 
 #### The hash ring
 
-A hash ring (stored in a key-value store) is used to achieve consistent hashing for the series sharding and replication across the ingesters. All [ingesters](#ingester) register themselves into the hash ring with a set of tokens they own; each token is a random unsigned 32-bit number. Each incoming series is [hashed](#hashing) in the distributor and then pushed to the ingester owning the tokens range for the series hash number plus N-1 subsequent ingesters in the ring, where N is the replication factor.
+A hash ring (stored in a key-value store) is used to achieve consistent hashing for the series sharding and replication across the ingesters. All [ingesters](#ingester) register themselves into the hash ring with a set of tokens they own; each token is a random unsigned 32-bit number. Each incoming series is [hashed](#hashing) in the distributor and then pushed to the ingester owning the token's range for the series hash number plus N-1 subsequent ingesters in the ring, where N is the replication factor.
 
 To do the hash lookup, distributors find the smallest appropriate token whose value is larger than the [hash of the series](#hashing). When the replication factor is larger than 1, the next subsequent tokens (clockwise in the ring) that belong to different ingesters will also be included in the result.
 
-The effect of this hash set up is that each token that an ingester owns is responsible for a range of hashes. If there are three tokens with values 0, 25, and 50, then a hash of 3 would be given to the ingester that owns the token 25; the ingester owning token 25 is responsible for the hash range of 1-25.
+The effect of this hash setup is that each token that an ingester owns is responsible for a range of hashes. If there are three tokens with values 0, 25, and 50, then a hash of 3 would be given to the ingester that owns token 25; the ingester owning token 25 is responsible for the hash range of 1-25.
 
 The supported KV stores for the hash ring are:
 
@@ -111,7 +111,7 @@ The supported KV stores for the hash ring are:
 
 #### Quorum consistency
 
-Since all distributors share access to the same hash ring, write requests can be sent to any distributor and you can setup a stateless load balancer in front of it.
+Since all distributors share access to the same hash ring, write requests can be sent to any distributor and you can set up a stateless load balancer in front of it.
 
 To ensure consistent query results, Cortex uses [Dynamo-style](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf) quorum consistency on reads and writes. This means that the distributor will wait for a positive response of at least one half plus one of the ingesters to send the sample to before successfully responding to the Prometheus write request.
 
@@ -125,35 +125,35 @@ The **ingester** service is responsible for writing incoming series to a [long-t
 
 Incoming series are not immediately written to the storage but kept in memory and periodically flushed to the storage (by default, 2 hours). For this reason, the [queriers](#querier) may need to fetch samples both from ingesters and long-term storage while executing a query on the read path.
 
-Ingesters contain a **lifecycler** which manages the lifecycle of an ingester and stores the **ingester state** in the [hash ring](#the-hash-ring). Each ingester could be in one of the following states:
+Ingesters contain a **lifecycler** which manages the lifecycle of an ingester and stores the **ingester state** in the [hash ring](#the-hash-ring). Each ingester can be in one of the following states:
 
 - **`PENDING`**<br />
-  The ingester has just started. While in this state, the ingester doesn't receive neither write and read requests.
+  The ingester has just started. While in this state, the ingester doesn't receive either write or read requests.
 - **`JOINING`**<br />
-  The ingester is starting up and joining the ring. While in this state the ingester doesn't receive neither write and read requests. The ingester will join the ring using tokens loaded from disk (if `-ingester.tokens-file-path` is configured) or generate a set of new random ones. Finally, the ingester optionally observes the ring for tokens conflicts and then, once any conflict is resolved, will move to `ACTIVE` state.
+  The ingester is starting up and joining the ring. While in this state the ingester doesn't receive either write or read requests. The ingester will join the ring using tokens loaded from disk (if `-ingester.tokens-file-path` is configured) or generate a set of new random ones. Finally, the ingester optionally observes the ring for token conflicts and then, once any conflict is resolved, will move to `ACTIVE` state.
 - **`ACTIVE`**<br />
   The ingester is up and running. While in this state the ingester can receive both write and read requests.
 - **`LEAVING`**<br />
-  The ingester is shutting down and leaving the ring. While in this state the ingester doesn't receive write requests, while it could receive read requests.
+  The ingester is shutting down and leaving the ring. While in this state the ingester doesn't receive write requests, while it can still receive read requests.
 - **`UNHEALTHY`**<br />
   The ingester has failed to heartbeat to the ring's KV Store. While in this state, distributors skip the ingester while building the replication set for incoming series and the ingester does not receive write or read requests.
 
 Ingesters are **semi-stateful**.
 
-#### Ingesters failure and data loss
+#### Ingester failure and data loss
 
 If an ingester process crashes or exits abruptly, all the in-memory series that have not yet been flushed to the long-term storage will be lost. There are two main ways to mitigate this failure mode:
 
 1. Replication
 2. Write-ahead log (WAL)
 
-The **replication** is used to hold multiple (typically 3) replicas of each time series in the ingesters. If the Cortex cluster loses an ingester, the in-memory series held by the lost ingester are also replicated to at least another ingester. In the event of a single ingester failure, no time series samples will be lost. However, in the event of multiple ingester failures, time series may be potentially lost if the failures affect all the ingesters holding the replicas of a specific time series.
+The **replication** is used to hold multiple (typically 3) replicas of each time series in the ingesters. If the Cortex cluster loses an ingester, the in-memory series held by the lost ingester are also replicated to at least one other ingester. In the event of a single ingester failure, no time series samples will be lost. However, in the event of multiple ingester failures, time series may be potentially lost if the failures affect all the ingesters holding the replicas of a specific time series.
 
 The **write-ahead log** (WAL) is used to write to a persistent disk all incoming series samples until they're flushed to the long-term storage. In the event of an ingester failure, a subsequent process restart will replay the WAL and recover the in-memory series samples.
 
-Contrary to the sole replication and given the persistent disk data is not lost, in the event of multiple ingesters failure each ingester will recover the in-memory series samples from WAL upon subsequent restart. The replication is still recommended in order to ensure no temporary failures on the read path in the event of a single ingester failure.
+Contrary to the sole replication and given that the persistent disk data is not lost, in the event of multiple ingester failures each ingester will recover the in-memory series samples from WAL upon subsequent restart. The replication is still recommended in order to ensure no temporary failures on the read path in the event of a single ingester failure.
 
-#### Ingesters write de-amplification
+#### Ingester write de-amplification
 
 Ingesters store recently received samples in-memory in order to perform write de-amplification. If the ingesters would immediately write received samples to the long-term storage, the system would be very difficult to scale due to the very high pressure on the storage. For this reason, the ingesters batch and compress samples in-memory and periodically flush them out to the storage.
 
@@ -169,10 +169,10 @@ Queriers are **stateless** and can be scaled up and down as needed.
 
 ### Compactor
 
-The **compactor** is a service which is responsible to:
+The **compactor** is a service which is responsible for:
 
-- Compact multiple blocks of a given tenant into a single optimized larger block. This helps to reduce storage costs (deduplication, index size reduction), and increase query speed (querying fewer blocks is faster).
-- Keep the per-tenant bucket index updated. The [bucket index](./blocks-storage/bucket-index.md) is used by [queriers](./blocks-storage/querier.md), [store-gateways](#store-gateway) and rulers to discover new blocks in the storage.
+- Compacting multiple blocks of a given tenant into a single optimized larger block. This helps to reduce storage costs (deduplication, index size reduction), and increase query speed (querying fewer blocks is faster).
+- Keeping the per-tenant bucket index updated. The [bucket index](./blocks-storage/bucket-index.md) is used by [queriers](./blocks-storage/querier.md), [store-gateways](#store-gateway) and rulers to discover new blocks in the storage.
 
 For more information, see the [compactor documentation](./blocks-storage/compactor.md).
 
@@ -190,7 +190,7 @@ The store gateway is **semi-stateful**.
 
 ### Query frontend
 
-The **query frontend** is an **optional service** providing the querier's API endpoints and can be used to accelerate the read path. When the query frontend is in place, incoming query requests should be directed to the query frontend instead of the queriers. The querier service will be still required within the cluster, in order to execute the actual queries.
+The **query frontend** is an **optional service** providing the querier's API endpoints and can be used to accelerate the read path. When the query frontend is in place, incoming query requests should be directed to the query frontend instead of the queriers. The querier service will still be required within the cluster, in order to execute the actual queries.
 
 The query frontend internally performs some query adjustments and holds queries in an internal queue. In this setup, queriers act as workers which pull jobs from the queue, execute them, and return them to the query-frontend for aggregation. Queriers need to be configured with the query frontend address (via the `-querier.frontend-address` CLI flag) in order to allow them to connect to the query frontends.
 
@@ -199,15 +199,15 @@ Query frontends are **stateless**. However, due to how the internal queue works,
 Flow of the query in the system when using query-frontend:
 
 1) Query is received by query frontend, which can optionally split it or serve from the cache.
-2) Query frontend stores the query into in-memory queue, where it waits for some querier to pick it up.
+2) Query frontend stores the query into an in-memory queue, where it waits for some querier to pick it up.
 3) Querier picks up the query, and executes it.
 4) Querier sends result back to query-frontend, which then forwards it to the client.
 
-Query frontend can also be used with any Prometheus-API compatible service. In this mode Cortex can be used as an query accelerator with it's caching and splitting features on other prometheus query engines like Thanos Querier or your own Prometheus server. Query frontend needs to be configured with downstream url address(via the `-frontend.downstream-url` CLI flag), which is the endpoint of the prometheus server intended to be connected with Cortex.
+Query frontend can also be used with any Prometheus-API compatible service. In this mode Cortex can be used as a query accelerator with its caching and splitting features on other prometheus query engines like Thanos Querier or your own Prometheus server. Query frontend needs to be configured with downstream url address (via the `-frontend.downstream-url` CLI flag), which is the endpoint of the prometheus server intended to be connected with Cortex.
 
 #### Queueing
 
-The query frontend queuing mechanism is used to:
+The query frontend queueing mechanism is used to:
 
 * Ensure that large queries, that could cause an out-of-memory (OOM) error in the querier, will be retried on failure. This allows administrators to under-provision memory for queries, or optimistically run more small queries in parallel, which helps to reduce the total cost of ownership (TCO).
 * Prevent multiple large requests from being convoyed on a single querier by distributing them across all queriers using a first-in/first-out queue (FIFO).
@@ -223,7 +223,7 @@ The query frontend supports caching query results and reuses them on subsequent 
 
 ### Query Scheduler
 
-Query Scheduler is an **optional** service that moves the internal queue from query frontend into separate component.
+Query Scheduler is an **optional** service that moves the internal queue from query frontend into a separate component.
 This enables independent scaling of query frontends and number of queues (query scheduler).
 
 In order to use query scheduler, both query frontend and queriers must be configured with query scheduler address
@@ -232,10 +232,10 @@ In order to use query scheduler, both query frontend and queriers must be config
 Flow of the query in the system changes when using query scheduler:
 
 1) Query is received by query frontend, which can optionally split it or serve from the cache.
-2) Query frontend forwards the query to random query scheduler process.
-3) Query scheduler stores the query into in-memory queue, where it waits for some querier to pick it up.
-3) Querier picks up the query, and executes it.
-4) Querier sends result back to query-frontend, which then forwards it to the client.
+2) Query frontend forwards the query to a random query scheduler process.
+3) Query scheduler stores the query into an in-memory queue, where it waits for some querier to pick it up.
+4) Querier picks up the query, and executes it.
+5) Querier sends result back to query-frontend, which then forwards it to the client.
 
 Query schedulers are **stateless**. It is recommended to run two replicas to make sure queries can still be serviced while one replica is restarting.
 
@@ -263,7 +263,7 @@ If all of the alertmanager nodes failed simultaneously there would be a loss of 
 ### Configs API
 
 The **configs API** is an **optional service** managing the configuration of Rulers and Alertmanagers.
-It provides APIs to get/set/update the ruler and alertmanager configurations and store them into backend.
-Current supported backend are PostgreSQL and in-memory.
+It provides APIs to get/set/update the ruler and alertmanager configurations and store them in the backend.
+Current supported backends are PostgreSQL and in-memory.
 
 Configs API is **stateless**.

--- a/docs/blocks-storage/querier.md
+++ b/docs/blocks-storage/querier.md
@@ -252,11 +252,22 @@ querier:
   # CLI flag: -querier.shuffle-sharding-ingesters-lookback-period
   [shuffle_sharding_ingesters_lookback_period: <duration> | default = 0s]
 
-  # Experimental. Use Thanos promql engine
-  # https://github.com/thanos-io/promql-engine rather than the Prometheus promql
-  # engine.
-  # CLI flag: -querier.thanos-engine
-  [thanos_engine: <boolean> | default = false]
+  thanos_engine:
+    # Experimental. Use Thanos promql engine
+    # https://github.com/thanos-io/promql-engine rather than the Prometheus
+    # promql engine.
+    # CLI flag: -querier.thanos-engine
+    [enabled: <boolean> | default = false]
+
+    # Enable xincrease, xdelta, xrate etc from Thanos engine.
+    # CLI flag: -querier.enable-x-functions
+    [enable_x_functions: <boolean> | default = false]
+
+    # Logical plan optimizers. Multiple optimizers can be provided as a
+    # comma-separated list. Supported values: default, all, propagate-matchers,
+    # sort-matchers, merge-selects, detect-histogram-stats
+    # CLI flag: -querier.optimizers
+    [optimizers: <string> | default = "default"]
 
   # If enabled, ignore max query length check at Querier select method. Users
   # can choose to ignore it since the validation can be done before Querier

--- a/docs/configuration/config-file-reference.md
+++ b/docs/configuration/config-file-reference.md
@@ -4302,11 +4302,22 @@ store_gateway_client:
 # CLI flag: -querier.shuffle-sharding-ingesters-lookback-period
 [shuffle_sharding_ingesters_lookback_period: <duration> | default = 0s]
 
-# Experimental. Use Thanos promql engine
-# https://github.com/thanos-io/promql-engine rather than the Prometheus promql
-# engine.
-# CLI flag: -querier.thanos-engine
-[thanos_engine: <boolean> | default = false]
+thanos_engine:
+  # Experimental. Use Thanos promql engine
+  # https://github.com/thanos-io/promql-engine rather than the Prometheus promql
+  # engine.
+  # CLI flag: -querier.thanos-engine
+  [enabled: <boolean> | default = false]
+
+  # Enable xincrease, xdelta, xrate etc from Thanos engine.
+  # CLI flag: -querier.enable-x-functions
+  [enable_x_functions: <boolean> | default = false]
+
+  # Logical plan optimizers. Multiple optimizers can be provided as a
+  # comma-separated list. Supported values: default, all, propagate-matchers,
+  # sort-matchers, merge-selects, detect-histogram-stats
+  # CLI flag: -querier.optimizers
+  [optimizers: <string> | default = "default"]
 
 # If enabled, ignore max query length check at Querier select method. Users can
 # choose to ignore it since the validation can be done before Querier evaluation
@@ -5023,6 +5034,23 @@ ring:
 # ruler.enable-ha-evaluation is true.
 # CLI flag: -ruler.liveness-check-timeout
 [liveness_check_timeout: <duration> | default = 1s]
+
+thanos_engine:
+  # Experimental. Use Thanos promql engine
+  # https://github.com/thanos-io/promql-engine rather than the Prometheus promql
+  # engine.
+  # CLI flag: -ruler.thanos-engine
+  [enabled: <boolean> | default = false]
+
+  # Enable xincrease, xdelta, xrate etc from Thanos engine.
+  # CLI flag: -ruler.enable-x-functions
+  [enable_x_functions: <boolean> | default = false]
+
+  # Logical plan optimizers. Multiple optimizers can be provided as a
+  # comma-separated list. Supported values: default, all, propagate-matchers,
+  # sort-matchers, merge-selects, detect-histogram-stats
+  # CLI flag: -ruler.optimizers
+  [optimizers: <string> | default = "default"]
 ```
 
 ### `ruler_storage_config`

--- a/integration/querier_test.go
+++ b/integration/querier_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/promql-engine/execution/parse"
 
 	"github.com/cortexproject/cortex/integration/e2e"
 	e2ecache "github.com/cortexproject/cortex/integration/e2e/cache"
@@ -416,6 +417,7 @@ func TestQuerierWithBlocksStorageRunningInSingleBinaryMode(t *testing.T) {
 						"-blocks-storage.bucket-store.bucket-index.enabled": strconv.FormatBool(testCfg.bucketIndexEnabled),
 						"-querier.query-store-for-labels-enabled":           "true",
 						"-querier.thanos-engine":                            strconv.FormatBool(thanosEngine),
+						"-querier.enable-x-functions":                       strconv.FormatBool(thanosEngine),
 						// Ingester.
 						"-ring.store":      "consul",
 						"-consul.hostname": consul.NetworkHTTPEndpoint(),
@@ -1309,4 +1311,67 @@ func TestQuerierMaxSamplesLimit(t *testing.T) {
 		ErrorType: v1.ErrExec,
 		Error:     "query processing would load too many samples into memory in query execution",
 	})
+}
+
+func TestQuerierEngineConfigs(t *testing.T) {
+	const blockRangePeriod = 5 * time.Second
+
+	s, err := e2e.NewScenario(networkName)
+	require.NoError(t, err)
+	defer s.Close()
+
+	// Configure the blocks storage to frequently compact TSDB head
+	// and ship blocks to the storage.
+	flags := mergeFlags(BlocksStorageFlags(), map[string]string{
+		"-blocks-storage.tsdb.block-ranges-period": blockRangePeriod.String(),
+		"-blocks-storage.tsdb.ship-interval":       "1s",
+		"-blocks-storage.tsdb.retention-period":    ((blockRangePeriod * 2) - 1).String(),
+		"-querier.thanos-engine":                   "true",
+		"-querier.enable-x-functions":              "true",
+		"-querier.optimizers":                      "all",
+	})
+
+	// Start dependencies.
+	minio := e2edb.NewMinio(9000, flags["-blocks-storage.s3.bucket-name"])
+	consul := e2edb.NewConsul()
+	require.NoError(t, s.StartAndWaitReady(consul, minio))
+
+	// Start Cortex components for the write path.
+	distributor := e2ecortex.NewDistributor("distributor", e2ecortex.RingStoreConsul, consul.NetworkHTTPEndpoint(), flags, "")
+	ingester := e2ecortex.NewIngester("ingester", e2ecortex.RingStoreConsul, consul.NetworkHTTPEndpoint(), flags, "")
+	require.NoError(t, s.StartAndWaitReady(distributor, ingester))
+
+	queryFrontend := e2ecortex.NewQueryFrontendWithConfigFile("query-frontend", "", flags, "")
+	require.NoError(t, s.Start(queryFrontend))
+
+	querier := e2ecortex.NewQuerier("querier", e2ecortex.RingStoreConsul, consul.NetworkHTTPEndpoint(), mergeFlags(flags, map[string]string{
+		"-querier.frontend-address": queryFrontend.NetworkGRPCEndpoint(),
+	}), "")
+	require.NoError(t, s.StartAndWaitReady(querier))
+
+	// Wait until the distributor and querier has updated the ring.
+	require.NoError(t, distributor.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+	require.NoError(t, querier.WaitSumMetrics(e2e.Equals(512), "cortex_ring_tokens_total"))
+
+	c, err := e2ecortex.NewClient(distributor.HTTPEndpoint(), queryFrontend.HTTPEndpoint(), "", "", "user-1")
+	require.NoError(t, err)
+
+	// Push some series to Cortex.
+	series1Timestamp := time.Now()
+	series1, _ := generateSeries("series_1", series1Timestamp, prompb.Label{Name: "job", Value: "test"})
+	series2, _ := generateSeries("series_2", series1Timestamp, prompb.Label{Name: "job", Value: "test"})
+
+	res, err := c.Push(series1)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+	res, err = c.Push(series2)
+	require.NoError(t, err)
+	require.Equal(t, 200, res.StatusCode)
+
+	for xFunc := range parse.XFunctions {
+		result, err := c.Query(fmt.Sprintf(`%s(series_1{job="test"}[1m])`, xFunc), series1Timestamp)
+		require.NoError(t, err)
+		require.Equal(t, model.ValVector, result.Type())
+	}
+
 }

--- a/integration/query_fuzz_test.go
+++ b/integration/query_fuzz_test.go
@@ -799,7 +799,7 @@ func TestVerticalShardingFuzz(t *testing.T) {
 	}
 	ps := promqlsmith.New(rnd, lbls, opts...)
 
-	runQueryFuzzTestCases(t, ps, c1, c2, now, start, end, scrapeInterval, 1000, false)
+	runQueryFuzzTestCases(t, ps, c1, c2, end, start, end, scrapeInterval, 1000, false)
 }
 
 func TestProtobufCodecFuzz(t *testing.T) {
@@ -1838,7 +1838,7 @@ func runQueryFuzzTestCases(t *testing.T, ps *promqlsmith.PromQLSmith, c1, c2 *e2
 				failures++
 			}
 		} else if !cmp.Equal(tc.res1, tc.res2, comparer) {
-			t.Logf("case %d results mismatch.\n%s: %s\nres1: %s\nres2: %s\n", i, qt, tc.query, tc.res1.String(), tc.res2.String())
+			t.Logf("case %d results mismatch.\n%s: %s\nres1 len: %d data: %s\nres2 len: %d data: %s\n", i, qt, tc.query, resultLength(tc.res1), tc.res1.String(), resultLength(tc.res2), tc.res2.String())
 			failures++
 		}
 	}
@@ -1871,4 +1871,18 @@ func isValidQuery(generatedQuery parser.Expr, skipStdAggregations bool) bool {
 		return false
 	}
 	return isValid
+}
+
+func resultLength(x model.Value) int {
+	vx, xvec := x.(model.Vector)
+	if xvec {
+		return vx.Len()
+	}
+
+	mx, xMatrix := x.(model.Matrix)
+	if xMatrix {
+		return mx.Len()
+	}
+	// Other type, return 0
+	return 0
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -77,8 +77,6 @@ type Config struct {
 	buildInfoEnabled bool `yaml:"build_info_enabled"`
 
 	QuerierDefaultCodec string `yaml:"querier_default_codec"`
-
-	DistributedExecEnabled bool `yaml:"distributed_exec_enabled" doc:"hidden"`
 }
 
 var (
@@ -91,7 +89,6 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.Var(&cfg.HTTPRequestHeadersToLog, "api.http-request-headers-to-log", "Which HTTP Request headers to add to logs")
 	f.BoolVar(&cfg.buildInfoEnabled, "api.build-info-enabled", false, "If enabled, build Info API will be served by query frontend or querier.")
 	f.StringVar(&cfg.QuerierDefaultCodec, "api.querier-default-codec", "json", "Choose default codec for querier response serialization. Supports 'json' and 'protobuf'.")
-	f.BoolVar(&cfg.DistributedExecEnabled, "frontend.distributed-exec-enabled", false, "Experimental: Enables distributed execution of queries by passing logical query plan fragments to downstream components.")
 	cfg.RegisterFlagsWithPrefix("", f)
 }
 
@@ -129,15 +126,14 @@ func compileCORSRegexString(s string) (*regexp.Regexp, error) {
 }
 
 type API struct {
-	AuthMiddleware         middleware.Interface
-	cfg                    Config
-	server                 *server.Server
-	logger                 log.Logger
-	sourceIPs              *middleware.SourceIPExtractor
-	indexPage              *IndexPageContent
-	HTTPHeaderMiddleware   *HTTPHeaderMiddleware
-	corsOrigin             *regexp.Regexp
-	distributedExecEnabled bool
+	AuthMiddleware       middleware.Interface
+	cfg                  Config
+	server               *server.Server
+	logger               log.Logger
+	sourceIPs            *middleware.SourceIPExtractor
+	indexPage            *IndexPageContent
+	HTTPHeaderMiddleware *HTTPHeaderMiddleware
+	corsOrigin           *regexp.Regexp
 }
 
 func New(cfg Config, serverCfg server.Config, s *server.Server, logger log.Logger) (*API, error) {
@@ -160,14 +156,13 @@ func New(cfg Config, serverCfg server.Config, s *server.Server, logger log.Logge
 	}
 
 	api := &API{
-		cfg:                    cfg,
-		AuthMiddleware:         cfg.HTTPAuthMiddleware,
-		server:                 s,
-		logger:                 logger,
-		sourceIPs:              sourceIPs,
-		indexPage:              newIndexPageContent(),
-		corsOrigin:             corsOrigin,
-		distributedExecEnabled: cfg.DistributedExecEnabled,
+		cfg:            cfg,
+		AuthMiddleware: cfg.HTTPAuthMiddleware,
+		server:         s,
+		logger:         logger,
+		sourceIPs:      sourceIPs,
+		indexPage:      newIndexPageContent(),
+		corsOrigin:     corsOrigin,
 	}
 
 	// If no authentication middleware is present in the config, use the default authentication middleware.

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -280,7 +280,7 @@ func NewQuerierHandler(
 	legacyPromRouter := route.New().WithPrefix(path.Join(legacyPrefix, "/api/v1"))
 	api.Register(legacyPromRouter)
 
-	queryAPI := queryapi.NewQueryAPI(engine, translateSampleAndChunkQueryable, statsRenderer, logger, codecs, corsOrigin)
+	queryAPI := queryapi.NewQueryAPI(engine, translateSampleAndChunkQueryable, statsRenderer, logger, codecs, corsOrigin, cfg.DistributedExecEnabled)
 
 	// TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
 	// https://github.com/prometheus/prometheus/pull/7125/files

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -167,7 +167,6 @@ func NewQuerierHandler(
 	metadataQuerier querier.MetadataQuerier,
 	reg prometheus.Registerer,
 	logger log.Logger,
-	distributedExecEnabled bool,
 ) http.Handler {
 	// Prometheus histograms for requests to the querier.
 	querierRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -163,7 +163,7 @@ func NewQuerierHandler(
 	cfg Config,
 	queryable storage.SampleAndChunkQueryable,
 	exemplarQueryable storage.ExemplarQueryable,
-	engine engine.Engine,
+	engine engine.BaseEngine,
 	metadataQuerier querier.MetadataQuerier,
 	reg prometheus.Registerer,
 	logger log.Logger,
@@ -200,7 +200,7 @@ func NewQuerierHandler(
 	corsOrigin := regexp.MustCompile(".*")
 	translateSampleAndChunkQueryable := querier.NewErrorTranslateSampleAndChunkQueryable(queryable)
 	api := v1.NewAPI(
-		&engine,
+		engine,
 		translateSampleAndChunkQueryable, // Translate errors to errors expected by API.
 		nil,                              // No remote write support.
 		exemplarQueryable,

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -281,7 +281,7 @@ func NewQuerierHandler(
 	legacyPromRouter := route.New().WithPrefix(path.Join(legacyPrefix, "/api/v1"))
 	api.Register(legacyPromRouter)
 
-	queryAPI := queryapi.NewQueryAPI(engine, translateSampleAndChunkQueryable, statsRenderer, logger, codecs, corsOrigin, distributedExecEnabled)
+	queryAPI := queryapi.NewQueryAPI(engine, translateSampleAndChunkQueryable, statsRenderer, logger, codecs, corsOrigin)
 
 	// TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
 	// https://github.com/prometheus/prometheus/pull/7125/files

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -163,10 +163,11 @@ func NewQuerierHandler(
 	cfg Config,
 	queryable storage.SampleAndChunkQueryable,
 	exemplarQueryable storage.ExemplarQueryable,
-	engine engine.BaseEngine,
+	engine engine.QueryEngine,
 	metadataQuerier querier.MetadataQuerier,
 	reg prometheus.Registerer,
 	logger log.Logger,
+	distributedExecEnabled bool,
 ) http.Handler {
 	// Prometheus histograms for requests to the querier.
 	querierRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
@@ -280,7 +281,7 @@ func NewQuerierHandler(
 	legacyPromRouter := route.New().WithPrefix(path.Join(legacyPrefix, "/api/v1"))
 	api.Register(legacyPromRouter)
 
-	queryAPI := queryapi.NewQueryAPI(engine, translateSampleAndChunkQueryable, statsRenderer, logger, codecs, corsOrigin, cfg.DistributedExecEnabled)
+	queryAPI := queryapi.NewQueryAPI(engine, translateSampleAndChunkQueryable, statsRenderer, logger, codecs, corsOrigin, distributedExecEnabled)
 
 	// TODO(gotjosh): This custom handler is temporary until we're able to vendor the changes in:
 	// https://github.com/prometheus/prometheus/pull/7125/files

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -19,13 +19,13 @@ import (
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/common/version"
 	"github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/weaveworks/common/instrument"
 	"github.com/weaveworks/common/middleware"
 
 	"github.com/cortexproject/cortex/pkg/api/queryapi"
+	"github.com/cortexproject/cortex/pkg/engine"
 	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/querier/codec"
 	"github.com/cortexproject/cortex/pkg/querier/stats"
@@ -163,7 +163,7 @@ func NewQuerierHandler(
 	cfg Config,
 	queryable storage.SampleAndChunkQueryable,
 	exemplarQueryable storage.ExemplarQueryable,
-	engine promql.QueryEngine,
+	engine engine.Engine,
 	metadataQuerier querier.MetadataQuerier,
 	reg prometheus.Registerer,
 	logger log.Logger,
@@ -200,7 +200,7 @@ func NewQuerierHandler(
 	corsOrigin := regexp.MustCompile(".*")
 	translateSampleAndChunkQueryable := querier.NewErrorTranslateSampleAndChunkQueryable(queryable)
 	api := v1.NewAPI(
-		engine,
+		&engine,
 		translateSampleAndChunkQueryable, // Translate errors to errors expected by API.
 		nil,                              // No remote write support.
 		exemplarQueryable,

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cortexproject/cortex/pkg/engine"
 	"github.com/prometheus/common/version"
 	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
@@ -232,7 +233,7 @@ func TestBuildInfoAPI(t *testing.T) {
 			version.Version = tc.version
 			version.Branch = tc.branch
 			version.Revision = tc.revision
-			handler := NewQuerierHandler(cfg, nil, nil, nil, nil, nil, &FakeLogger{})
+			handler := NewQuerierHandler(cfg, nil, nil, engine.Engine{}, nil, nil, &FakeLogger{})
 			writer := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/api/v1/status/buildinfo", nil)
 			req = req.WithContext(user.InjectOrgID(req.Context(), "test"))

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -232,7 +232,7 @@ func TestBuildInfoAPI(t *testing.T) {
 			version.Version = tc.version
 			version.Branch = tc.branch
 			version.Revision = tc.revision
-			handler := NewQuerierHandler(cfg, nil, nil, nil, nil, nil, &FakeLogger{}, false)
+			handler := NewQuerierHandler(cfg, nil, nil, nil, nil, nil, &FakeLogger{})
 			writer := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/api/v1/status/buildinfo", nil)
 			req = req.WithContext(user.InjectOrgID(req.Context(), "test"))

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cortexproject/cortex/pkg/engine"
 	"github.com/prometheus/common/version"
 	v1 "github.com/prometheus/prometheus/web/api/v1"
 	"github.com/stretchr/testify/assert"
@@ -233,7 +232,7 @@ func TestBuildInfoAPI(t *testing.T) {
 			version.Version = tc.version
 			version.Branch = tc.branch
 			version.Revision = tc.revision
-			handler := NewQuerierHandler(cfg, nil, nil, engine.Engine{}, nil, nil, &FakeLogger{})
+			handler := NewQuerierHandler(cfg, nil, nil, nil, nil, nil, &FakeLogger{})
 			writer := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/api/v1/status/buildinfo", nil)
 			req = req.WithContext(user.InjectOrgID(req.Context(), "test"))

--- a/pkg/api/handlers_test.go
+++ b/pkg/api/handlers_test.go
@@ -232,7 +232,7 @@ func TestBuildInfoAPI(t *testing.T) {
 			version.Version = tc.version
 			version.Branch = tc.branch
 			version.Revision = tc.revision
-			handler := NewQuerierHandler(cfg, nil, nil, nil, nil, nil, &FakeLogger{})
+			handler := NewQuerierHandler(cfg, nil, nil, nil, nil, nil, &FakeLogger{}, false)
 			writer := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/api/v1/status/buildinfo", nil)
 			req = req.WithContext(user.InjectOrgID(req.Context(), "test"))

--- a/pkg/api/queryapi/query_api.go
+++ b/pkg/api/queryapi/query_api.go
@@ -111,11 +111,11 @@ func (q *QueryAPI) RangeQueryHandler(r *http.Request) (result apiFuncResult) {
 	if len(byteLP) != 0 {
 		logicalPlan, err := logicalplan.Unmarshal(byteLP)
 		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("invalid logical plan: %v", err)}, nil, nil}
+			return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("invalid logical plan: %v", err)}, nil, nil}
 		}
 		qry, err = q.queryEngine.MakeRangeQueryFromPlan(ctx, q.queryable, opts, logicalPlan, startTime, endTime, stepDuration, r.FormValue("query"))
 		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("failed to create range query from logical plan: %v", err)}, nil, nil}
+			return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("failed to create range query from logical plan: %v", err)}, nil, nil}
 		}
 	} else { // if there is logical plan field is empty, fall back
 		qry, err = q.queryEngine.NewRangeQuery(ctx, q.queryable, opts, r.FormValue("query"), startTime, endTime, stepDuration)
@@ -184,11 +184,11 @@ func (q *QueryAPI) InstantQueryHandler(r *http.Request) (result apiFuncResult) {
 	if len(byteLP) != 0 {
 		logicalPlan, err := logicalplan.Unmarshal(byteLP)
 		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("invalid logical plan: %v", err)}, nil, nil}
+			return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("invalid logical plan: %v", err)}, nil, nil}
 		}
 		qry, err = q.queryEngine.MakeInstantQueryFromPlan(ctx, q.queryable, opts, logicalPlan, tsTime, r.FormValue("query"))
 		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, fmt.Errorf("failed to create range query from logical plan: %v", err)}, nil, nil}
+			return apiFuncResult{nil, &apiError{errorInternal, fmt.Errorf("failed to create instant query from logical plan: %v", err)}, nil, nil}
 		}
 	} else { // if there is logical plan field is empty, fall back
 		qry, err = q.queryEngine.NewInstantQuery(ctx, q.queryable, opts, r.FormValue("query"), tsTime)

--- a/pkg/api/queryapi/query_api.go
+++ b/pkg/api/queryapi/query_api.go
@@ -3,7 +3,6 @@ package queryapi
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
@@ -111,11 +110,8 @@ func (q *QueryAPI) RangeQueryHandler(r *http.Request) (result apiFuncResult) {
 	endTime := convertMsToTime(end)
 	stepDuration := convertMsToDuration(step)
 
-	byteLP, err := io.ReadAll(r.Body)
 	if q.distributedExecEnabled {
-		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
-		}
+		byteLP := []byte(r.PostFormValue("plan"))
 		if len(byteLP) != 0 {
 			logicalPlan, err := logicalplan.Unmarshal(byteLP)
 			if err != nil {
@@ -205,10 +201,7 @@ func (q *QueryAPI) InstantQueryHandler(r *http.Request) (result apiFuncResult) {
 	tsTime := convertMsToTime(ts)
 
 	if q.distributedExecEnabled {
-		byteLP, err := io.ReadAll(r.Body)
-		if err != nil {
-			return apiFuncResult{nil, &apiError{errorBadData, err}, nil, nil}
-		}
+		byteLP := []byte(r.PostFormValue("plan"))
 		if len(byteLP) != 0 {
 			logicalPlan, err := logicalplan.Unmarshal(byteLP)
 			if err != nil {

--- a/pkg/api/queryapi/query_api.go
+++ b/pkg/api/queryapi/query_api.go
@@ -11,23 +11,23 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/grafana/regexp"
 	"github.com/munnerz/goautoneg"
+	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/httputil"
 	v1 "github.com/prometheus/prometheus/web/api/v1"
+	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/weaveworks/common/httpgrpc"
 
 	"github.com/cortexproject/cortex/pkg/engine"
 	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/api"
-	"github.com/prometheus/prometheus/promql"
-	"github.com/thanos-io/promql-engine/logicalplan"
 )
 
 type QueryAPI struct {
 	queryable     storage.SampleAndChunkQueryable
-	queryEngine   engine.Engine
+	queryEngine   engine.BaseEngine
 	now           func() time.Time
 	statsRenderer v1.StatsRenderer
 	logger        log.Logger
@@ -36,7 +36,7 @@ type QueryAPI struct {
 }
 
 func NewQueryAPI(
-	qe engine.Engine,
+	qe engine.BaseEngine,
 	q storage.SampleAndChunkQueryable,
 	statsRenderer v1.StatsRenderer,
 	logger log.Logger,

--- a/pkg/api/queryapi/query_api_test.go
+++ b/pkg/api/queryapi/query_api_test.go
@@ -1,13 +1,14 @@
 package queryapi
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -457,8 +458,13 @@ func Test_Logicalplan_Requests(t *testing.T) {
 	}
 }
 
-func createTestRequest(path string, body []byte) *http.Request {
-	req := httptest.NewRequest(http.MethodPost, path, io.NopCloser(bytes.NewReader(body)))
+func createTestRequest(path string, planBytes []byte) *http.Request {
+	form := url.Values{}
+	form.Set("plan", string(planBytes))
+	req := httptest.NewRequest(http.MethodPost, path, io.NopCloser(strings.NewReader(form.Encode())))
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	
 	ctx := context.Background()
 	_, ctx = stats.ContextWithEmptyStats(ctx)
 	return req.WithContext(user.InjectOrgID(ctx, "user1"))

--- a/pkg/api/queryapi/query_api_test.go
+++ b/pkg/api/queryapi/query_api_test.go
@@ -182,7 +182,7 @@ func Test_CustomAPI(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"))
+			c := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"), false)
 
 			router := mux.NewRouter()
 			router.Path("/api/v1/query").Methods("POST").Handler(c.Wrap(c.InstantQueryHandler))
@@ -243,7 +243,7 @@ func Test_InvalidCodec(t *testing.T) {
 		},
 	}
 
-	queryAPI := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{&mockCodec{}}, regexp.MustCompile(".*"))
+	queryAPI := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{&mockCodec{}}, regexp.MustCompile(".*"), false)
 	router := mux.NewRouter()
 	router.Path("/api/v1/query").Methods("POST").Handler(queryAPI.Wrap(queryAPI.InstantQueryHandler))
 
@@ -284,7 +284,7 @@ func Test_CustomAPI_StatsRenderer(t *testing.T) {
 		},
 	}
 
-	queryAPI := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"))
+	queryAPI := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"), false)
 
 	router := mux.NewRouter()
 	router.Path("/api/v1/query_range").Methods("POST").Handler(queryAPI.Wrap(queryAPI.RangeQueryHandler))
@@ -440,7 +440,7 @@ func Test_Logicalplan_Requests(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"))
+			c := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"), true)
 			router := mux.NewRouter()
 			router.Path("/api/v1/query").Methods("POST").Handler(c.Wrap(c.InstantQueryHandler))
 			router.Path("/api/v1/query_range").Methods("POST").Handler(c.Wrap(c.RangeQueryHandler))

--- a/pkg/api/queryapi/query_api_test.go
+++ b/pkg/api/queryapi/query_api_test.go
@@ -362,7 +362,7 @@ func Test_Logicalplan_Requests(t *testing.T) {
 				return append(createTestLogicalPlan(t, 1536673665, 1536673680, 5), []byte("random data")...)
 			},
 			expectedCode: http.StatusInternalServerError,
-			expectedBody: `{"status":"error","errorType":"server_error","error":"invalid character 'r' after top-level value"}`,
+			expectedBody: `{"status":"error","errorType":"server_error","error":"invalid logical plan: invalid character 'r' after top-level value"}`,
 		},
 		{
 			name:         "[Range Query] with empty body and non-empty query string", // fall back to promql query execution
@@ -410,7 +410,7 @@ func Test_Logicalplan_Requests(t *testing.T) {
 				return append(createTestLogicalPlan(t, 1536673670, 1536673670, 0), []byte("random data")...)
 			},
 			expectedCode: http.StatusInternalServerError,
-			expectedBody: `{"status":"error","errorType":"server_error","error":"invalid character 'r' after top-level value"}`,
+			expectedBody: `{"status":"error","errorType":"server_error","error":"invalid logical plan: invalid character 'r' after top-level value"}`,
 		},
 		{
 			name:         "[Instant Query] with empty body and non-empty query string",

--- a/pkg/api/queryapi/query_api_test.go
+++ b/pkg/api/queryapi/query_api_test.go
@@ -183,7 +183,7 @@ func Test_CustomAPI(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			c := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"), false)
+			c := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"))
 
 			router := mux.NewRouter()
 			router.Path("/api/v1/query").Methods("POST").Handler(c.Wrap(c.InstantQueryHandler))
@@ -244,7 +244,7 @@ func Test_InvalidCodec(t *testing.T) {
 		},
 	}
 
-	queryAPI := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{&mockCodec{}}, regexp.MustCompile(".*"), false)
+	queryAPI := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{&mockCodec{}}, regexp.MustCompile(".*"))
 	router := mux.NewRouter()
 	router.Path("/api/v1/query").Methods("POST").Handler(queryAPI.Wrap(queryAPI.InstantQueryHandler))
 
@@ -285,7 +285,7 @@ func Test_CustomAPI_StatsRenderer(t *testing.T) {
 		},
 	}
 
-	queryAPI := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"), false)
+	queryAPI := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"))
 
 	router := mux.NewRouter()
 	router.Path("/api/v1/query_range").Methods("POST").Handler(queryAPI.Wrap(queryAPI.RangeQueryHandler))
@@ -441,7 +441,7 @@ func Test_Logicalplan_Requests(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"), true)
+			c := NewQueryAPI(engine, mockQueryable, querier.StatsRenderer, log.NewNopLogger(), []v1.Codec{v1.JSONCodec{}}, regexp.MustCompile(".*"))
 			router := mux.NewRouter()
 			router.Path("/api/v1/query").Methods("POST").Handler(c.Wrap(c.InstantQueryHandler))
 			router.Path("/api/v1/query_range").Methods("POST").Handler(c.Wrap(c.RangeQueryHandler))
@@ -464,7 +464,6 @@ func createTestRequest(path string, planBytes []byte) *http.Request {
 	req := httptest.NewRequest(http.MethodPost, path, io.NopCloser(strings.NewReader(form.Encode())))
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	
 	ctx := context.Background()
 	_, ctx = stats.ContextWithEmptyStats(ctx)
 	return req.WithContext(user.InjectOrgID(ctx, "user1"))

--- a/pkg/api/queryapi/query_api_test.go
+++ b/pkg/api/queryapi/query_api_test.go
@@ -76,7 +76,7 @@ func Test_CustomAPI(t *testing.T) {
 			MaxSamples: 100,
 			Timeout:    time.Second * 2,
 		},
-		false,
+		engine2.ThanosEngineConfig{Enabled: false},
 		prometheus.NewRegistry())
 
 	mockQueryable := &mockSampleAndChunkQueryable{
@@ -225,7 +225,7 @@ func Test_InvalidCodec(t *testing.T) {
 			MaxSamples: 100,
 			Timeout:    time.Second * 2,
 		},
-		false,
+		engine2.ThanosEngineConfig{Enabled: false},
 		prometheus.NewRegistry())
 
 	mockQueryable := &mockSampleAndChunkQueryable{
@@ -264,7 +264,7 @@ func Test_CustomAPI_StatsRenderer(t *testing.T) {
 			MaxSamples: 100,
 			Timeout:    time.Second * 2,
 		},
-		false,
+		engine2.ThanosEngineConfig{Enabled: false},
 		prometheus.NewRegistry())
 
 	mockQueryable := &mockSampleAndChunkQueryable{
@@ -311,7 +311,7 @@ func Test_Logicalplan_Requests(t *testing.T) {
 			MaxSamples: 100,
 			Timeout:    time.Second * 2,
 		},
-		true,
+		engine2.ThanosEngineConfig{Enabled: true},
 		prometheus.NewRegistry(),
 	)
 

--- a/pkg/configs/userconfig/config.go
+++ b/pkg/configs/userconfig/config.go
@@ -9,10 +9,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/rules"
 	"gopkg.in/yaml.v3"
 
+	"github.com/cortexproject/cortex/pkg/parser"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 

--- a/pkg/configs/userconfig/config_test.go
+++ b/pkg/configs/userconfig/config_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/rulefmt"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 
+	"github.com/cortexproject/cortex/pkg/parser"
 	util_log "github.com/cortexproject/cortex/pkg/util/log"
 )
 

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -322,7 +322,7 @@ type Cortex struct {
 	QuerierQueryable         prom_storage.SampleAndChunkQueryable
 	ExemplarQueryable        prom_storage.ExemplarQueryable
 	MetadataQuerier          querier.MetadataQuerier
-	QuerierEngine            engine.BaseEngine
+	QuerierEngine            engine.QueryEngine
 	QueryFrontendTripperware tripperware.Tripperware
 	ResourceMonitor          *resource.Monitor
 

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -322,7 +322,7 @@ type Cortex struct {
 	QuerierQueryable         prom_storage.SampleAndChunkQueryable
 	ExemplarQueryable        prom_storage.ExemplarQueryable
 	MetadataQuerier          querier.MetadataQuerier
-	QuerierEngine            engine.Engine
+	QuerierEngine            engine.BaseEngine
 	QueryFrontendTripperware tripperware.Tripperware
 	ResourceMonitor          *resource.Monitor
 

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/promql"
 	prom_storage "github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/common/server"
 	"github.com/weaveworks/common/signals"
@@ -35,6 +34,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/cortex/storage"
 	"github.com/cortexproject/cortex/pkg/cortexpb"
 	"github.com/cortexproject/cortex/pkg/distributor"
+	"github.com/cortexproject/cortex/pkg/engine"
 	"github.com/cortexproject/cortex/pkg/flusher"
 	"github.com/cortexproject/cortex/pkg/frontend"
 	frontendv1 "github.com/cortexproject/cortex/pkg/frontend/v1"
@@ -322,7 +322,7 @@ type Cortex struct {
 	QuerierQueryable         prom_storage.SampleAndChunkQueryable
 	ExemplarQueryable        prom_storage.ExemplarQueryable
 	MetadataQuerier          querier.MetadataQuerier
-	QuerierEngine            promql.QueryEngine
+	QuerierEngine            engine.Engine
 	QueryFrontendTripperware tripperware.Tripperware
 	ResourceMonitor          *resource.Monitor
 

--- a/pkg/cortex/cortex.go
+++ b/pkg/cortex/cortex.go
@@ -379,6 +379,7 @@ func New(cfg Config) (*Cortex, error) {
 		return nil, err
 	}
 
+	cortex.setupPromQLFunctions()
 	return cortex, nil
 }
 
@@ -536,4 +537,10 @@ func (t *Cortex) readyHandler(sm *services.Manager) http.HandlerFunc {
 
 		util.WriteTextResponse(w, "ready")
 	}
+}
+
+func (t *Cortex) setupPromQLFunctions() {
+	// The holt_winters function is renamed to double_exponential_smoothing and has been experimental since Prometheus v3. (https://github.com/prometheus/prometheus/pull/14930)
+	// The cortex supports holt_winters for users using this function.
+	querier.EnableExperimentalPromQLFunctions(t.Cfg.Querier.EnablePromQLExperimentalFunctions, true)
 }

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -371,7 +371,6 @@ func (t *Cortex) initQuerier() (serv services.Service, err error) {
 		t.MetadataQuerier,
 		prometheus.DefaultRegisterer,
 		util_log.Logger,
-		t.Cfg.Querier.DistributedExecEnabled,
 	)
 
 	// If the querier is running standalone without the query-frontend or query-scheduler, we must register it's internal

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -672,7 +672,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 		// TODO: Consider wrapping logger to differentiate from querier module logger
 		queryable, _, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, rulerRegisterer, util_log.Logger, t.Overrides.RulesPartialData)
 
-		managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Distributor, queryable, &engine, t.Overrides, metrics, prometheus.DefaultRegisterer)
+		managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Distributor, queryable, engine, t.Overrides, metrics, prometheus.DefaultRegisterer)
 		manager, err = ruler.NewDefaultMultiTenantManager(t.Cfg.Ruler, t.Overrides, managerFactory, metrics, prometheus.DefaultRegisterer, util_log.Logger)
 	}
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -371,6 +371,7 @@ func (t *Cortex) initQuerier() (serv services.Service, err error) {
 		t.MetadataQuerier,
 		prometheus.DefaultRegisterer,
 		util_log.Logger,
+		t.Cfg.Querier.DistributedExecEnabled,
 	)
 
 	// If the querier is running standalone without the query-frontend or query-scheduler, we must register it's internal
@@ -541,7 +542,7 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 		shardedPrometheusCodec,
 		t.Cfg.Querier.LookbackDelta,
 		t.Cfg.Querier.DefaultEvaluationInterval,
-		t.Cfg.Frontend.DistributedExecEnabled,
+		t.Cfg.Querier.DistributedExecEnabled,
 	)
 	if err != nil {
 		return nil, err
@@ -554,7 +555,7 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 		queryAnalyzer,
 		t.Cfg.Querier.LookbackDelta,
 		t.Cfg.Querier.DefaultEvaluationInterval,
-		t.Cfg.Frontend.DistributedExecEnabled)
+		t.Cfg.Querier.DistributedExecEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -672,7 +672,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 		// TODO: Consider wrapping logger to differentiate from querier module logger
 		queryable, _, engine := querier.New(t.Cfg.Querier, t.Overrides, t.Distributor, t.StoreQueryables, rulerRegisterer, util_log.Logger, t.Overrides.RulesPartialData)
 
-		managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Distributor, queryable, engine, t.Overrides, metrics, prometheus.DefaultRegisterer)
+		managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Distributor, queryable, &engine, t.Overrides, metrics, prometheus.DefaultRegisterer)
 		manager, err = ruler.NewDefaultMultiTenantManager(t.Cfg.Ruler, t.Overrides, managerFactory, metrics, prometheus.DefaultRegisterer, util_log.Logger)
 	}
 

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+
 	"log/slog"
 	"net/http"
 	"runtime"
@@ -18,8 +19,6 @@ import (
 	"github.com/prometheus/prometheus/rules"
 	prom_storage "github.com/prometheus/prometheus/storage"
 	"github.com/thanos-io/objstore"
-	"github.com/thanos-io/promql-engine/engine"
-	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/thanos/pkg/discovery/dns"
 	"github.com/thanos-io/thanos/pkg/querysharding"
 	httpgrpc_server "github.com/weaveworks/common/httpgrpc/server"
@@ -32,6 +31,7 @@ import (
 	configAPI "github.com/cortexproject/cortex/pkg/configs/api"
 	"github.com/cortexproject/cortex/pkg/configs/db"
 	"github.com/cortexproject/cortex/pkg/distributor"
+	"github.com/cortexproject/cortex/pkg/engine"
 	"github.com/cortexproject/cortex/pkg/flusher"
 	"github.com/cortexproject/cortex/pkg/frontend"
 	"github.com/cortexproject/cortex/pkg/frontend/transport"
@@ -564,7 +564,6 @@ func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err erro
 		t.Cfg.Querier.DefaultEvaluationInterval,
 		t.Cfg.Querier.MaxSubQuerySteps,
 		t.Cfg.Querier.LookbackDelta,
-		t.Cfg.Querier.EnablePromQLExperimentalFunctions,
 	)
 
 	return services.NewIdleService(nil, func(_ error) error {
@@ -643,7 +642,6 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 	if t.Cfg.ExternalPusher != nil && t.Cfg.ExternalQueryable != nil {
 		rulerRegisterer := prometheus.WrapRegistererWith(prometheus.Labels{"engine": "ruler"}, prometheus.DefaultRegisterer)
 
-		var queryEngine promql.QueryEngine
 		opts := promql.EngineOpts{
 			Logger:               util_log.SLogger,
 			Reg:                  rulerRegisterer,
@@ -658,15 +656,7 @@ func (t *Cortex) initRuler() (serv services.Service, err error) {
 				return t.Cfg.Querier.DefaultEvaluationInterval.Milliseconds()
 			},
 		}
-		if t.Cfg.Querier.ThanosEngine {
-			queryEngine = engine.New(engine.Opts{
-				EngineOpts:        opts,
-				LogicalOptimizers: logicalplan.AllOptimizers,
-				EnableAnalysis:    true,
-			})
-		} else {
-			queryEngine = promql.NewEngine(opts)
-		}
+		queryEngine := engine.New(opts, t.Cfg.Ruler.ThanosEngine, rulerRegisterer)
 
 		managerFactory := ruler.DefaultTenantManagerFactory(t.Cfg.Ruler, t.Cfg.ExternalPusher, t.Cfg.ExternalQueryable, queryEngine, t.Overrides, metrics, prometheus.DefaultRegisterer)
 		manager, err = ruler.NewDefaultMultiTenantManager(t.Cfg.Ruler, t.Overrides, managerFactory, metrics, prometheus.DefaultRegisterer, util_log.Logger)

--- a/pkg/cortex/modules.go
+++ b/pkg/cortex/modules.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cortexproject/cortex/pkg/querier/tripperware/instantquery"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware/queryrange"
 	querier_worker "github.com/cortexproject/cortex/pkg/querier/worker"
+	cortexquerysharding "github.com/cortexproject/cortex/pkg/querysharding"
 	"github.com/cortexproject/cortex/pkg/ring"
 	"github.com/cortexproject/cortex/pkg/ring/kv/codec"
 	"github.com/cortexproject/cortex/pkg/ring/kv/memberlist"
@@ -511,7 +512,13 @@ func (t *Cortex) initFlusher() (serv services.Service, err error) {
 // initQueryFrontendTripperware instantiates the tripperware used by the query frontend
 // to optimize Prometheus query requests.
 func (t *Cortex) initQueryFrontendTripperware() (serv services.Service, err error) {
-	queryAnalyzer := querysharding.NewQueryAnalyzer()
+	var queryAnalyzer querysharding.Analyzer
+	queryAnalyzer = querysharding.NewQueryAnalyzer()
+	if t.Cfg.Querier.EnableParquetQueryable {
+		// Disable vertical sharding for binary expression with ignore for parquet queryable.
+		queryAnalyzer = cortexquerysharding.NewDisableBinaryExpressionAnalyzer(queryAnalyzer)
+	}
+
 	// PrometheusCodec is a codec to encode and decode Prometheus query range requests and responses.
 	prometheusCodec := queryrange.NewPrometheusCodec(false, t.Cfg.Querier.ResponseCompression, t.Cfg.API.QuerierDefaultCodec)
 	// ShardedPrometheusCodec is same as PrometheusCodec but to be used on the sharded queries (it sum up the stats)

--- a/pkg/engine/config.go
+++ b/pkg/engine/config.go
@@ -1,0 +1,63 @@
+package engine
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/thanos-io/promql-engine/logicalplan"
+)
+
+var supportedOptimizers = []string{"default", "all", "propagate-matchers", "sort-matchers", "merge-selects", "detect-histogram-stats"}
+
+// ThanosEngineConfig contains the configuration to create engine
+type ThanosEngineConfig struct {
+	Enabled           bool                    `yaml:"enabled"`
+	EnableXFunctions  bool                    `yaml:"enable_x_functions"`
+	Optimizers        string                  `yaml:"optimizers"`
+	LogicalOptimizers []logicalplan.Optimizer `yaml:"-"`
+}
+
+func (cfg *ThanosEngineConfig) RegisterFlagsWithPrefix(prefix string, f *flag.FlagSet) {
+	f.BoolVar(&cfg.Enabled, prefix+"thanos-engine", false, "Experimental. Use Thanos promql engine https://github.com/thanos-io/promql-engine rather than the Prometheus promql engine.")
+	f.BoolVar(&cfg.EnableXFunctions, prefix+"enable-x-functions", false, "Enable xincrease, xdelta, xrate etc from Thanos engine.")
+	f.StringVar(&cfg.Optimizers, prefix+"optimizers", "default", "Logical plan optimizers. Multiple optimizers can be provided as a comma-separated list. Supported values: "+strings.Join(supportedOptimizers, ", "))
+}
+
+func (cfg *ThanosEngineConfig) Validate() error {
+	splitOptimizers := strings.Split(cfg.Optimizers, ",")
+
+	for _, optimizer := range splitOptimizers {
+		if optimizer == "all" || optimizer == "default" {
+			if len(splitOptimizers) > 1 {
+				return fmt.Errorf("special optimizer %s cannot be combined with other optimizers", optimizer)
+			}
+		}
+		optimizers, err := getOptimizer(optimizer)
+		if err != nil {
+			return err
+		}
+		cfg.LogicalOptimizers = append(cfg.LogicalOptimizers, optimizers...)
+	}
+
+	return nil
+}
+
+func getOptimizer(name string) ([]logicalplan.Optimizer, error) {
+	switch name {
+	case "default":
+		return logicalplan.DefaultOptimizers, nil
+	case "all":
+		return logicalplan.AllOptimizers, nil
+	case "propagate-matchers":
+		return []logicalplan.Optimizer{logicalplan.PropagateMatchersOptimizer{}}, nil
+	case "sort-matchers":
+		return []logicalplan.Optimizer{logicalplan.SortMatchers{}}, nil
+	case "merge-selects":
+		return []logicalplan.Optimizer{logicalplan.MergeSelectsOptimizer{}}, nil
+	case "detect-histogram-stats":
+		return []logicalplan.Optimizer{logicalplan.DetectHistogramStatsOptimizer{}}, nil
+	default:
+		return nil, fmt.Errorf("unknown optimizer %s", name)
+	}
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -43,6 +43,13 @@ func GetEngineType(ctx context.Context) Type {
 	return None
 }
 
+type BaseEngine interface {
+	NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error)
+	NewRangeQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error)
+	MakeInstantQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, root logicalplan.Node, ts time.Time, qs string) (promql.Query, error)
+	MakeRangeQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, root logicalplan.Node, start time.Time, end time.Time, interval time.Duration, qs string) (promql.Query, error)
+}
+
 type Engine struct {
 	prometheusEngine *promql.Engine
 	thanosEngine     *thanosengine.Engine

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -43,7 +43,7 @@ func GetEngineType(ctx context.Context) Type {
 	return None
 }
 
-type BaseEngine interface {
+type QueryEngine interface {
 	NewInstantQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, ts time.Time) (promql.Query, error)
 	NewRangeQuery(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, qs string, start, end time.Time, interval time.Duration) (promql.Query, error)
 	MakeInstantQueryFromPlan(ctx context.Context, q storage.Queryable, opts promql.QueryOpts, root logicalplan.Node, ts time.Time, qs string) (promql.Query, error)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	thanosengine "github.com/thanos-io/promql-engine/engine"
+	"github.com/thanos-io/promql-engine/logicalplan"
 )
 
 type engineKeyType struct{}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/storage"
 	thanosengine "github.com/thanos-io/promql-engine/engine"
-	"github.com/thanos-io/promql-engine/logicalplan"
 )
 
 type engineKeyType struct{}
@@ -52,15 +51,16 @@ type Engine struct {
 	engineSwitchQueriesTotal *prometheus.CounterVec
 }
 
-func New(opts promql.EngineOpts, enableThanosEngine bool, reg prometheus.Registerer) *Engine {
+func New(opts promql.EngineOpts, thanosEngineCfg ThanosEngineConfig, reg prometheus.Registerer) *Engine {
 	prometheusEngine := promql.NewEngine(opts)
 
 	var thanosEngine *thanosengine.Engine
-	if enableThanosEngine {
+	if thanosEngineCfg.Enabled {
 		thanosEngine = thanosengine.New(thanosengine.Opts{
 			EngineOpts:        opts,
-			LogicalOptimizers: logicalplan.DefaultOptimizers,
+			LogicalOptimizers: thanosEngineCfg.LogicalOptimizers,
 			EnableAnalysis:    true,
+			EnableXFunctions:  thanosEngineCfg.EnableXFunctions,
 		})
 	}
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/thanos-io/promql-engine/execution/parse"
-	"github.com/thanos-io/promql-engine/execution/parse"
 	"github.com/thanos-io/promql-engine/logicalplan"
 	"github.com/thanos-io/promql-engine/query"
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -14,8 +14,12 @@ import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
-	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/promql-engine/execution/parse"
+	"github.com/thanos-io/promql-engine/execution/parse"
+	"github.com/thanos-io/promql-engine/logicalplan"
+	"github.com/thanos-io/promql-engine/query"
+
+	"github.com/stretchr/testify/require"
 
 	utillog "github.com/cortexproject/cortex/pkg/util/log"
 )
@@ -122,4 +126,98 @@ func TestEngine_XFunctions(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestEngine_With_Logical_Plan(t *testing.T) {
+	ctx := context.Background()
+	reg := prometheus.NewRegistry()
+
+	now := time.Now()
+	start := time.Now().Add(-time.Minute * 5)
+	step := time.Minute
+	queryable := promqltest.LoadedStorage(t, "")
+	opts := promql.EngineOpts{
+		Logger: utillog.GoKitLogToSlog(log.NewNopLogger()),
+		Reg:    reg,
+	}
+	queryEngine := New(opts, ThanosEngineConfig{Enabled: true}, reg)
+
+	range_lp := createTestLogicalPlan(t, start, now, step, "up")
+	instant_lp := createTestLogicalPlan(t, now, now, 0, "up")
+
+	r := &http.Request{Header: http.Header{}}
+	r.Header.Set(TypeHeader, string(Thanos))
+	ctx = AddEngineTypeToContext(ctx, r)
+
+	// Case 1: Executing logical plan with thanos engine
+	_, _ = queryEngine.MakeInstantQueryFromPlan(ctx, queryable, nil, instant_lp.Root(), now, "up")
+	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP cortex_thanos_engine_fallback_queries_total Total number of fallback queries due to not implementation in thanos engine
+		# TYPE cortex_thanos_engine_fallback_queries_total counter
+		cortex_thanos_engine_fallback_queries_total 0
+	`), "cortex_thanos_engine_fallback_queries_total"))
+
+	_, _ = queryEngine.MakeRangeQueryFromPlan(ctx, queryable, nil, range_lp.Root(), start, now, step, "up")
+	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP cortex_thanos_engine_fallback_queries_total Total number of fallback queries due to not implementation in thanos engine
+		# TYPE cortex_thanos_engine_fallback_queries_total counter
+		cortex_thanos_engine_fallback_queries_total 0
+	`), "cortex_thanos_engine_fallback_queries_total"))
+
+	// Case 2: Logical plan that thanos engine cannot execute (so it will fall back to prometheus engine)
+	err_range_lp := createTestLogicalPlan(t, start, now, step, "up[10]")
+	_, _ = queryEngine.MakeRangeQueryFromPlan(ctx, queryable, nil, err_range_lp.Root(), start, now, step, "up")
+	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP cortex_thanos_engine_fallback_queries_total Total number of fallback queries due to not implementation in thanos engine
+		# TYPE cortex_thanos_engine_fallback_queries_total counter
+		cortex_thanos_engine_fallback_queries_total 1
+	`), "cortex_thanos_engine_fallback_queries_total"))
+
+	// Case 3: executing with prometheus engine
+	r.Header.Set(TypeHeader, string(Prometheus))
+	ctx = AddEngineTypeToContext(ctx, r)
+
+	_, _ = queryEngine.MakeInstantQueryFromPlan(ctx, queryable, nil, instant_lp.Root(), now, "up")
+	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP cortex_engine_switch_queries_total Total number of queries where engine_type is set explicitly
+		# TYPE cortex_engine_switch_queries_total counter
+		cortex_engine_switch_queries_total{engine_type="prometheus"} 1
+		cortex_engine_switch_queries_total{engine_type="thanos"} 3
+	`), "cortex_engine_switch_queries_total"))
+
+	_, _ = queryEngine.MakeRangeQueryFromPlan(ctx, queryable, nil, range_lp.Root(), start, now, step, "up")
+	require.NoError(t, testutil.GatherAndCompare(reg, bytes.NewBufferString(`
+		# HELP cortex_engine_switch_queries_total Total number of queries where engine_type is set explicitly
+		# TYPE cortex_engine_switch_queries_total counter
+		cortex_engine_switch_queries_total{engine_type="prometheus"} 2
+		cortex_engine_switch_queries_total{engine_type="thanos"} 3
+	`), "cortex_engine_switch_queries_total"))
+}
+
+func createTestLogicalPlan(t *testing.T, startTime time.Time, endTime time.Time, step time.Duration, q string) logicalplan.Plan {
+
+	qOpts := query.Options{
+		Start:              startTime,
+		End:                startTime,
+		Step:               0,
+		StepsBatch:         10,
+		LookbackDelta:      0,
+		EnablePerStepStats: false,
+	}
+
+	if step != 0 {
+		qOpts.End = endTime
+		qOpts.Step = step
+	}
+
+	expr, err := parser.NewParser(q, parser.WithFunctions(parser.Functions)).ParseExpr()
+	require.NoError(t, err)
+
+	planOpts := logicalplan.PlanOptions{
+		DisableDuplicateLabelCheck: false,
+	}
+
+	logicalPlan := logicalplan.NewFromAST(expr, &qOpts, planOpts)
+
+	return logicalPlan
 }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/promql/promqltest"
 	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/promql-engine/execution/parse"
 
 	utillog "github.com/cortexproject/cortex/pkg/util/log"
 )
@@ -37,7 +39,7 @@ func TestEngine_Fallback(t *testing.T) {
 		Logger: utillog.GoKitLogToSlog(log.NewNopLogger()),
 		Reg:    reg,
 	}
-	queryEngine := New(opts, true, reg)
+	queryEngine := New(opts, ThanosEngineConfig{Enabled: true}, reg)
 
 	// instant query, should go to fallback
 	_, _ = queryEngine.NewInstantQuery(ctx, queryable, nil, "unimplemented(foo)", now)
@@ -68,7 +70,7 @@ func TestEngine_Switch(t *testing.T) {
 		Logger: utillog.GoKitLogToSlog(log.NewNopLogger()),
 		Reg:    reg,
 	}
-	queryEngine := New(opts, true, reg)
+	queryEngine := New(opts, ThanosEngineConfig{Enabled: true}, reg)
 
 	// Query Prometheus engine
 	r := &http.Request{Header: http.Header{}}
@@ -95,4 +97,29 @@ func TestEngine_Switch(t *testing.T) {
 		cortex_engine_switch_queries_total{engine_type="prometheus"} 2
 		cortex_engine_switch_queries_total{engine_type="thanos"} 2
 	`), "cortex_engine_switch_queries_total"))
+}
+
+func TestEngine_XFunctions(t *testing.T) {
+	ctx := context.Background()
+	reg := prometheus.NewRegistry()
+
+	now := time.Now()
+	start := time.Now().Add(-time.Minute * 5)
+	step := time.Minute
+	queryable := promqltest.LoadedStorage(t, "")
+	opts := promql.EngineOpts{
+		Logger: utillog.GoKitLogToSlog(log.NewNopLogger()),
+		Reg:    reg,
+	}
+	queryEngine := New(opts, ThanosEngineConfig{Enabled: true, EnableXFunctions: true}, reg)
+
+	for name := range parse.XFunctions {
+		t.Run(name, func(t *testing.T) {
+			_, err := queryEngine.NewInstantQuery(ctx, queryable, nil, fmt.Sprintf("%s(foo[1m])", name), now)
+			require.NoError(t, err)
+
+			_, err = queryEngine.NewRangeQuery(ctx, queryable, nil, fmt.Sprintf("%s(foo[1m])", name), start, now, step)
+			require.NoError(t, err)
+		})
+	}
 }

--- a/pkg/frontend/config.go
+++ b/pkg/frontend/config.go
@@ -20,8 +20,7 @@ type CombinedFrontendConfig struct {
 	FrontendV1 v1.Config               `yaml:",inline"`
 	FrontendV2 v2.Config               `yaml:",inline"`
 
-	DownstreamURL          string `yaml:"downstream_url"`
-	DistributedExecEnabled bool   `yaml:"distributed_exec_enabled" doc:"hidden"`
+	DownstreamURL string `yaml:"downstream_url"`
 }
 
 func (cfg *CombinedFrontendConfig) RegisterFlags(f *flag.FlagSet) {
@@ -30,7 +29,6 @@ func (cfg *CombinedFrontendConfig) RegisterFlags(f *flag.FlagSet) {
 	cfg.FrontendV2.RegisterFlags(f)
 
 	f.StringVar(&cfg.DownstreamURL, "frontend.downstream-url", "", "URL of downstream Prometheus.")
-	f.BoolVar(&cfg.DistributedExecEnabled, "frontend.distributed-exec-enabled", false, "Experimental: Enables distributed execution of queries by passing logical query plan fragments to downstream components.")
 }
 
 // InitFrontend initializes frontend (either V1 -- without scheduler, or V2 -- with scheduler) or no frontend at

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,0 +1,21 @@
+package parser
+
+import (
+	"maps"
+
+	promqlparser "github.com/prometheus/prometheus/promql/parser"
+	"github.com/thanos-io/promql-engine/execution/parse"
+)
+
+var functions = buildFunctions()
+
+func buildFunctions() map[string]*promqlparser.Function {
+	fns := make(map[string]*promqlparser.Function, len(promqlparser.Functions))
+	maps.Copy(fns, promqlparser.Functions)
+	maps.Copy(fns, parse.XFunctions)
+	return fns
+}
+
+func ParseExpr(qs string) (promqlparser.Expr, error) {
+	return promqlparser.NewParser(qs, promqlparser.WithFunctions(functions)).ParseExpr()
+}

--- a/pkg/querier/parquet_queryable_test.go
+++ b/pkg/querier/parquet_queryable_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -74,49 +75,6 @@ func TestParquetQueryableFallbackLogic(t *testing.T) {
 		labels.MustNewMatcher(labels.MatchEqual, labels.MetricName, "fromSg"),
 	}
 	ctx := user.InjectOrgID(context.Background(), "user-1")
-
-	t.Run("should fallback when vertical sharding is enabled", func(t *testing.T) {
-		finder := &blocksFinderMock{}
-		stores := createStore()
-
-		q := &blocksStoreQuerier{
-			minT:        minT,
-			maxT:        maxT,
-			finder:      finder,
-			stores:      stores,
-			consistency: NewBlocksConsistencyChecker(0, 0, log.NewNopLogger(), nil),
-			logger:      log.NewNopLogger(),
-			metrics:     newBlocksStoreQueryableMetrics(prometheus.NewPedanticRegistry()),
-			limits:      &blocksStoreLimitsMock{},
-
-			storeGatewayConsistencyCheckMaxAttempts: 3,
-		}
-
-		mParquetQuerier := &mockParquetQuerier{}
-		pq := &parquetQuerierWithFallback{
-			minT:                  minT,
-			maxT:                  maxT,
-			finder:                finder,
-			blocksStoreQuerier:    q,
-			parquetQuerier:        mParquetQuerier,
-			metrics:               newParquetQueryableFallbackMetrics(prometheus.NewRegistry()),
-			limits:                defaultOverrides(t, 4),
-			logger:                log.NewNopLogger(),
-			defaultBlockStoreType: parquetBlockStore,
-		}
-
-		finder.On("GetBlocks", mock.Anything, "user-1", minT, maxT).Return(bucketindex.Blocks{
-			&bucketindex.Block{ID: block1, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
-			&bucketindex.Block{ID: block2, Parquet: &parquet.ConverterMarkMeta{Version: 1}},
-		}, map[ulid.ULID]*bucketindex.BlockDeletionMark(nil), nil)
-
-		t.Run("select", func(t *testing.T) {
-			ss := pq.Select(ctx, true, nil, matchers...)
-			require.NoError(t, ss.Err())
-			require.Len(t, stores.queriedBlocks, 2)
-			require.Len(t, mParquetQuerier.queriedBlocks, 0)
-		})
-	})
 
 	t.Run("should fallback all blocks", func(t *testing.T) {
 		finder := &blocksFinderMock{}
@@ -670,4 +628,91 @@ func (m *mockParquetQuerier) Reset() {
 
 func (mockParquetQuerier) Close() error {
 	return nil
+}
+
+func TestMaterializedLabelsFilterCallback(t *testing.T) {
+	tests := []struct {
+		name                     string
+		setupContext             func() context.Context
+		expectedFilterReturned   bool
+		expectedCallbackReturned bool
+	}{
+		{
+			name: "no shard matcher in context",
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			expectedFilterReturned:   false,
+			expectedCallbackReturned: false,
+		},
+		{
+			name: "shard matcher exists but is not sharded",
+			setupContext: func() context.Context {
+				// Create a ShardInfo with TotalShards = 0 (not sharded)
+				shardInfo := &storepb.ShardInfo{
+					ShardIndex:  0,
+					TotalShards: 0, // Not sharded
+					By:          true,
+					Labels:      []string{"__name__"},
+				}
+
+				buffers := &sync.Pool{New: func() interface{} {
+					b := make([]byte, 0, 100)
+					return &b
+				}}
+				shardMatcher := shardInfo.Matcher(buffers)
+
+				return injectShardMatcherIntoContext(context.Background(), shardMatcher)
+			},
+			expectedFilterReturned:   false,
+			expectedCallbackReturned: false,
+		},
+		{
+			name: "shard matcher exists and is sharded",
+			setupContext: func() context.Context {
+				// Create a ShardInfo with TotalShards > 0 (sharded)
+				shardInfo := &storepb.ShardInfo{
+					ShardIndex:  0,
+					TotalShards: 2, // Sharded
+					By:          true,
+					Labels:      []string{"__name__"},
+				}
+
+				buffers := &sync.Pool{New: func() interface{} {
+					b := make([]byte, 0, 100)
+					return &b
+				}}
+				shardMatcher := shardInfo.Matcher(buffers)
+
+				return injectShardMatcherIntoContext(context.Background(), shardMatcher)
+			},
+			expectedFilterReturned:   true,
+			expectedCallbackReturned: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setupContext()
+
+			filter, exists := materializedLabelsFilterCallback(ctx, nil)
+
+			require.Equal(t, tt.expectedCallbackReturned, exists)
+
+			if tt.expectedFilterReturned {
+				require.NotNil(t, filter)
+
+				// Test that the filter can be used
+				testLabels := labels.FromStrings("__name__", "test_metric", "label1", "value1")
+				// We can't easily test the actual filtering logic without knowing the internal
+				// shard matching implementation, but we can at least verify the filter interface works
+				_ = filter.Filter(testLabels)
+
+				// Cleanup
+				filter.Close()
+			} else {
+				require.Nil(t, filter)
+			}
+		})
+	}
 }

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -200,7 +200,7 @@ func getChunksIteratorFunction(_ Config) chunkIteratorFunc {
 }
 
 // New builds a queryable and promql engine.
-func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger, isPartialDataEnabled partialdata.IsCfgEnabledFunc) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, engine.Engine) {
+func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger, isPartialDataEnabled partialdata.IsCfgEnabledFunc) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, engine.BaseEngine) {
 	iteratorFunc := getChunksIteratorFunction(cfg)
 
 	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, iteratorFunc, cfg.QueryIngestersWithin, isPartialDataEnabled, cfg.IngesterQueryMaxAttempts)
@@ -246,7 +246,7 @@ func New(cfg Config, limits *validation.Overrides, distributor Distributor, stor
 		},
 	}
 	queryEngine := engine.New(opts, cfg.ThanosEngine, reg)
-	return NewSampleAndChunkQueryable(lazyQueryable), exemplarQueryable, *queryEngine
+	return NewSampleAndChunkQueryable(lazyQueryable), exemplarQueryable, queryEngine
 }
 
 // NewSampleAndChunkQueryable creates a SampleAndChunkQueryable from a

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -95,6 +95,7 @@ type Config struct {
 	EnableParquetQueryable            bool   `yaml:"enable_parquet_queryable" doc:"hidden"`
 	ParquetQueryableShardCacheSize    int    `yaml:"parquet_queryable_shard_cache_size" doc:"hidden"`
 	ParquetQueryableDefaultBlockStore string `yaml:"parquet_queryable_default_block_store" doc:"hidden"`
+	DistributedExecEnabled            bool   `yaml:"distributed_exec_enabled" doc:"hidden"`
 }
 
 var (
@@ -145,6 +146,7 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 	f.BoolVar(&cfg.EnableParquetQueryable, "querier.enable-parquet-queryable", false, "[Experimental] If true, querier will try to query the parquet files if available.")
 	f.IntVar(&cfg.ParquetQueryableShardCacheSize, "querier.parquet-queryable-shard-cache-size", 512, "[Experimental] [Experimental] Maximum size of the Parquet queryable shard cache. 0 to disable.")
 	f.StringVar(&cfg.ParquetQueryableDefaultBlockStore, "querier.parquet-queryable-default-block-store", string(parquetBlockStore), "Parquet queryable's default block store to query. Valid options are tsdb and parquet. If it is set to tsdb, parquet queryable always fallback to store gateway.")
+	f.BoolVar(&cfg.DistributedExecEnabled, "querier.distributed-exec-enabled", false, "Experimental: Enables distributed execution of queries by passing logical query plan fragments to downstream components.")
 }
 
 // Validate the config
@@ -200,7 +202,7 @@ func getChunksIteratorFunction(_ Config) chunkIteratorFunc {
 }
 
 // New builds a queryable and promql engine.
-func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger, isPartialDataEnabled partialdata.IsCfgEnabledFunc) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, engine.BaseEngine) {
+func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger, isPartialDataEnabled partialdata.IsCfgEnabledFunc) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, engine.QueryEngine) {
 	iteratorFunc := getChunksIteratorFunction(cfg)
 
 	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, iteratorFunc, cfg.QueryIngestersWithin, isPartialDataEnabled, cfg.IngesterQueryMaxAttempts)

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -200,7 +200,7 @@ func getChunksIteratorFunction(_ Config) chunkIteratorFunc {
 }
 
 // New builds a queryable and promql engine.
-func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger, isPartialDataEnabled partialdata.IsCfgEnabledFunc) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, promql.QueryEngine) {
+func New(cfg Config, limits *validation.Overrides, distributor Distributor, stores []QueryableWithFilter, reg prometheus.Registerer, logger log.Logger, isPartialDataEnabled partialdata.IsCfgEnabledFunc) (storage.SampleAndChunkQueryable, storage.ExemplarQueryable, engine.Engine) {
 	iteratorFunc := getChunksIteratorFunction(cfg)
 
 	distributorQueryable := newDistributorQueryable(distributor, cfg.IngesterMetadataStreaming, cfg.IngesterLabelNamesWithMatchers, iteratorFunc, cfg.QueryIngestersWithin, isPartialDataEnabled, cfg.IngesterQueryMaxAttempts)
@@ -246,7 +246,7 @@ func New(cfg Config, limits *validation.Overrides, distributor Distributor, stor
 		},
 	}
 	queryEngine := engine.New(opts, cfg.ThanosEngine, reg)
-	return NewSampleAndChunkQueryable(lazyQueryable), exemplarQueryable, queryEngine
+	return NewSampleAndChunkQueryable(lazyQueryable), exemplarQueryable, *queryEngine
 }
 
 // NewSampleAndChunkQueryable creates a SampleAndChunkQueryable from a

--- a/pkg/querier/tripperware/instantquery/instant_query.go
+++ b/pkg/querier/tripperware/instantquery/instant_query.go
@@ -183,7 +183,7 @@ func (c instantQueryCodec) EncodeRequest(ctx context.Context, r tripperware.Requ
 		}
 	}
 
-	h.Add("Content-Type", "application/json")
+	h.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	isSourceRuler := strings.Contains(h.Get("User-Agent"), tripperware.RulerUserAgent)
 	if !isSourceRuler {
@@ -191,16 +191,19 @@ func (c instantQueryCodec) EncodeRequest(ctx context.Context, r tripperware.Requ
 		tripperware.SetRequestHeaders(h, c.defaultCodecType, c.compression)
 	}
 
-	byteBody, err := c.getSerializedBody(promReq)
+	bodyBytes, err := c.getSerializedBody(promReq)
 	if err != nil {
 		return nil, err
 	}
+	form := url.Values{}
+	form.Set("plan", string(bodyBytes))
+	formEncoded := form.Encode()
 
 	req := &http.Request{
 		Method:     "POST",
 		RequestURI: u.String(), // This is what the httpgrpc code looks at.
 		URL:        u,
-		Body:       io.NopCloser(bytes.NewReader(byteBody)),
+		Body:       io.NopCloser(strings.NewReader(formEncoded)),
 		Header:     h,
 	}
 

--- a/pkg/querier/tripperware/instantquery/instant_query_middlewares_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_middlewares_test.go
@@ -212,8 +212,7 @@ func TestRoundTripWithAndWithoutDistributedExec(t *testing.T) {
 			require.NoError(t, err)
 
 			// check request body
-			body, err := io.ReadAll(req.Body)
-			require.NoError(t, err)
+			body := []byte(req.PostFormValue("plan"))
 			if tc.expectEmptyBody {
 				require.Empty(t, body)
 			} else {

--- a/pkg/querier/tripperware/instantquery/instant_query_middlewares_test.go
+++ b/pkg/querier/tripperware/instantquery/instant_query_middlewares_test.go
@@ -79,7 +79,6 @@ func TestRoundTrip(t *testing.T) {
 		time.Minute,
 		0,
 		0,
-		false,
 	)
 
 	for i, tc := range []struct {
@@ -192,7 +191,6 @@ func TestRoundTripWithAndWithoutDistributedExec(t *testing.T) {
 				time.Minute,
 				0,
 				0,
-				false,
 			)
 
 			ctx := user.InjectOrgID(context.Background(), "1")

--- a/pkg/querier/tripperware/instantquery/limits.go
+++ b/pkg/querier/tripperware/instantquery/limits.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/httpgrpc"
 
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util/promql"
@@ -45,7 +45,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r tripperware.Request) (trippe
 
 	// Enforce the max query length.
 	if maxQueryLength := validation.SmallestPositiveNonZeroDurationPerTenant(tenantIDs, l.MaxQueryLength); maxQueryLength > 0 {
-		expr, err := parser.ParseExpr(r.GetQuery())
+		expr, err := cortexparser.ParseExpr(r.GetQuery())
 		if err != nil {
 			return nil, httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error())
 		}

--- a/pkg/querier/tripperware/instantquery/limits_test.go
+++ b/pkg/querier/tripperware/instantquery/limits_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -24,7 +24,7 @@ func TestLimitsMiddleware_MaxQueryLength(t *testing.T) {
 	)
 
 	wrongQuery := `up[`
-	_, parserErr := parser.ParseExpr(wrongQuery)
+	_, parserErr := cortexparser.ParseExpr(wrongQuery)
 
 	tests := map[string]struct {
 		maxQueryLength time.Duration

--- a/pkg/querier/tripperware/merge.go
+++ b/pkg/querier/tripperware/merge.go
@@ -10,6 +10,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/strutil"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 )
 
 const StatusSuccess = "success"
@@ -284,7 +285,7 @@ func getSortValueFromPair(samples []*pair, i int) float64 {
 }
 
 func sortPlanForQuery(q string) (sortPlan, error) {
-	expr, err := promqlparser.ParseExpr(q)
+	expr, err := cortexparser.ParseExpr(q)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/querier/tripperware/query_attribute_matcher.go
+++ b/pkg/querier/tripperware/query_attribute_matcher.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/httpgrpc"
 
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/querier/stats"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/validation"
@@ -24,7 +24,7 @@ func rejectQueryOrSetPriority(r *http.Request, now time.Time, lookbackDelta time
 
 	if op == "query" || op == "query_range" {
 		query := r.FormValue("query")
-		expr, err := parser.ParseExpr(query)
+		expr, err := cortexparser.ParseExpr(query)
 		if err != nil {
 			return httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error())
 		}

--- a/pkg/querier/tripperware/queryrange/limits.go
+++ b/pkg/querier/tripperware/queryrange/limits.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/prometheus/model/timestamp"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/httpgrpc"
 
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
@@ -82,7 +82,7 @@ func (l limitsMiddleware) Do(ctx context.Context, r tripperware.Request) (trippe
 			return nil, httpgrpc.Errorf(http.StatusBadRequest, validation.ErrQueryTooLong, queryLen, maxQueryLength)
 		}
 
-		expr, err := parser.ParseExpr(r.GetQuery())
+		expr, err := cortexparser.ParseExpr(r.GetQuery())
 		if err != nil {
 			return nil, httpgrpc.Errorf(http.StatusBadRequest, "%s", err.Error())
 		}

--- a/pkg/querier/tripperware/queryrange/limits_test.go
+++ b/pkg/querier/tripperware/queryrange/limits_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
+	"github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/validation"

--- a/pkg/querier/tripperware/queryrange/query_range.go
+++ b/pkg/querier/tripperware/queryrange/query_range.go
@@ -189,8 +189,7 @@ func (c prometheusCodec) EncodeRequest(ctx context.Context, r tripperware.Reques
 			h.Add(n, v)
 		}
 	}
-
-	h.Add("Content-Type", "application/json")
+	h.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	tripperware.SetRequestHeaders(h, c.defaultCodecType, c.compression)
 
@@ -199,11 +198,15 @@ func (c prometheusCodec) EncodeRequest(ctx context.Context, r tripperware.Reques
 		return nil, err
 	}
 
+	form := url.Values{}
+	form.Set("plan", string(bodyBytes))
+	formEncoded := form.Encode()
+
 	req := &http.Request{
 		Method:     "POST",
 		RequestURI: u.String(), // This is what the httpgrpc code looks at.
 		URL:        u,
-		Body:       io.NopCloser(bytes.NewReader(bodyBytes)),
+		Body:       io.NopCloser(strings.NewReader(formEncoded)),
 		Header:     h,
 	}
 

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
@@ -231,8 +231,7 @@ func TestRoundTripWithAndWithoutDistributedExec(t *testing.T) {
 			require.NoError(t, err)
 
 			// check request body
-			body, err := io.ReadAll(req.Body)
-			require.NoError(t, err)
+			body := []byte(req.PostFormValue("plan"))
 			if tc.expectEmptyBody {
 				require.Empty(t, body)
 			} else {

--- a/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
+++ b/pkg/querier/tripperware/queryrange/query_range_middlewares_test.go
@@ -86,7 +86,6 @@ func TestRoundTrip(t *testing.T) {
 		time.Minute,
 		0,
 		0,
-		false,
 	)
 
 	for i, tc := range []struct {
@@ -211,7 +210,6 @@ func TestRoundTripWithAndWithoutDistributedExec(t *testing.T) {
 				time.Minute,
 				0,
 				0,
-				false,
 			)
 
 			ctx := user.InjectOrgID(context.Background(), "1")

--- a/pkg/querier/tripperware/queryrange/results_cache.go
+++ b/pkg/querier/tripperware/queryrange/results_cache.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cortexproject/cortex/pkg/chunk/cache"
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/querier/partialdata"
 	querier_stats "github.com/cortexproject/cortex/pkg/querier/stats"
@@ -326,7 +327,7 @@ func (s resultsCache) isAtModifierCachable(ctx context.Context, r tripperware.Re
 	if !strings.Contains(query, "@") {
 		return true
 	}
-	expr, err := parser.ParseExpr(query)
+	expr, err := cortexparser.ParseExpr(query)
 	if err != nil {
 		// We are being pessimistic in such cases.
 		level.Warn(util_log.WithContext(ctx, s.logger)).Log("msg", "failed to parse query, considering @ modifier as not cacheable", "query", query, "err", err)
@@ -371,7 +372,7 @@ func (s resultsCache) isOffsetCachable(ctx context.Context, r tripperware.Reques
 	if !strings.Contains(query, "offset") {
 		return true
 	}
-	expr, err := parser.ParseExpr(query)
+	expr, err := cortexparser.ParseExpr(query)
 	if err != nil {
 		level.Warn(util_log.WithContext(ctx, s.logger)).Log("msg", "failed to parse query, considering offset as not cacheable", "query", query, "err", err)
 		return false

--- a/pkg/querier/tripperware/queryrange/split_by_interval.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval.go
@@ -11,6 +11,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/querysharding"
 	"github.com/weaveworks/common/httpgrpc"
 
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	querier_stats "github.com/cortexproject/cortex/pkg/querier/stats"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 	"github.com/cortexproject/cortex/pkg/tenant"
@@ -111,7 +112,7 @@ func splitQuery(r tripperware.Request, interval time.Duration) ([]tripperware.Re
 // For example given the start of the query is 10.00, `http_requests_total[1h] @ start()` query will be replaced with `http_requests_total[1h] @ 10.00`
 // If the modifier is already a constant, it will be returned as is.
 func evaluateAtModifierFunction(query string, start, end int64) (string, error) {
-	expr, err := parser.ParseExpr(query)
+	expr, err := cortexparser.ParseExpr(query)
 	if err != nil {
 		return "", httpgrpc.Errorf(http.StatusBadRequest, "%s", err)
 	}
@@ -167,7 +168,7 @@ func dynamicIntervalFn(cfg Config, limits tripperware.Limits, queryAnalyzer quer
 			return ctx, baseInterval, nil
 		}
 
-		queryExpr, err := parser.ParseExpr(r.GetQuery())
+		queryExpr, err := cortexparser.ParseExpr(r.GetQuery())
 		if err != nil {
 			return ctx, baseInterval, err
 		}

--- a/pkg/querier/tripperware/queryrange/split_by_interval_test.go
+++ b/pkg/querier/tripperware/queryrange/split_by_interval_test.go
@@ -10,15 +10,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/thanos-io/thanos/pkg/querysharding"
 	"github.com/weaveworks/common/httpgrpc"
-
-	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/middleware"
 	"github.com/weaveworks/common/user"
 	"go.uber.org/atomic"
 
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/querier/tripperware"
 )
 
@@ -434,7 +433,7 @@ func Test_evaluateAtModifier(t *testing.T) {
 				require.Equal(t, tt.expectedErrorCode, int(httpResp.Code))
 			} else {
 				require.NoError(t, err)
-				expectedExpr, err := parser.ParseExpr(tt.expected)
+				expectedExpr, err := cortexparser.ParseExpr(tt.expected)
 				require.NoError(t, err)
 				require.Equal(t, expectedExpr.String(), out)
 			}
@@ -1044,7 +1043,7 @@ func Test_analyzeDurationFetchedByQuery(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			expr, err := parser.ParseExpr(tc.req.GetQuery())
+			expr, err := cortexparser.ParseExpr(tc.req.GetQuery())
 			require.Nil(t, err)
 			durationFetchedByRange, durationFetchedBySelectors := analyzeDurationFetchedByQueryExpr(expr, tc.req.GetStart(), tc.req.GetEnd(), tc.baseSplitInterval, tc.lookbackDelta)
 			require.Equal(t, tc.expectedDurationFetchedByRange, durationFetchedByRange)

--- a/pkg/querier/tripperware/roundtrip.go
+++ b/pkg/querier/tripperware/roundtrip.go
@@ -31,7 +31,6 @@ import (
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
-	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/tenant"
 	"github.com/cortexproject/cortex/pkg/util"
 	"github.com/cortexproject/cortex/pkg/util/limiter"
@@ -117,12 +116,7 @@ func NewQueryTripperware(
 	defaultSubQueryInterval time.Duration,
 	maxSubQuerySteps int64,
 	lookbackDelta time.Duration,
-	enablePromQLExperimentalFunctions bool,
 ) Tripperware {
-
-	// The holt_winters function is renamed to double_exponential_smoothing and has been experimental since Prometheus v3. (https://github.com/prometheus/prometheus/pull/14930)
-	// The cortex supports holt_winters for users using this function.
-	querier.EnableExperimentalPromQLFunctions(enablePromQLExperimentalFunctions, true)
 
 	// Per tenant query metrics.
 	queriesPerTenant := promauto.With(registerer).NewCounterVec(prometheus.CounterOpts{

--- a/pkg/querier/tripperware/roundtrip_test.go
+++ b/pkg/querier/tripperware/roundtrip_test.go
@@ -347,7 +347,6 @@ cortex_query_frontend_queries_total{op="query", source="api", user="1"} 1
 				time.Minute,
 				tc.maxSubQuerySteps,
 				0,
-				false,
 			)
 			resp, err := tw(downstream).RoundTrip(req)
 			if tc.expectedErr == nil {

--- a/pkg/querier/tripperware/subquery.go
+++ b/pkg/querier/tripperware/subquery.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/weaveworks/common/httpgrpc"
+
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 )
 
 var (
@@ -18,7 +20,7 @@ const (
 
 // SubQueryStepSizeCheck ensures the query doesn't contain too small step size in subqueries.
 func SubQueryStepSizeCheck(query string, defaultSubQueryInterval time.Duration, maxStep int64) error {
-	expr, err := parser.ParseExpr(query)
+	expr, err := cortexparser.ParseExpr(query)
 	if err != nil {
 		// If query fails to parse, we don't throw step size error
 		// but fail query later on querier.

--- a/pkg/querier/tripperware/test_shard_by_query_utils.go
+++ b/pkg/querier/tripperware/test_shard_by_query_utils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 	"github.com/weaveworks/common/user"
 
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/querysharding"
 	"github.com/cortexproject/cortex/pkg/util/validation"
 )
@@ -413,7 +414,7 @@ http_requests_total`,
 			s := httptest.NewServer(
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					q := r.FormValue("query")
-					expr, _ := parser.ParseExpr(q)
+					expr, _ := cortexparser.ParseExpr(q)
 					shardIndex := int64(0)
 
 					parser.Inspect(expr, func(n parser.Node, _ []parser.Node) error {

--- a/pkg/querysharding/util.go
+++ b/pkg/querysharding/util.go
@@ -4,8 +4,10 @@ import (
 	"encoding/base64"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/thanos-io/thanos/pkg/querysharding"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 
 	cortexparser "github.com/cortexproject/cortex/pkg/parser"
@@ -20,6 +22,8 @@ var (
 		b := make([]byte, 0, 100)
 		return &b
 	}}
+
+	stop = errors.New("stop")
 )
 
 func InjectShardingInfo(query string, shardInfo *storepb.ShardInfo) (string, error) {
@@ -76,4 +80,44 @@ func ExtractShardingMatchers(matchers []*labels.Matcher) ([]*labels.Matcher, *st
 	}
 
 	return r, shardInfo.Matcher(&buffers), nil
+}
+
+type disableBinaryExpressionAnalyzer struct {
+	analyzer querysharding.Analyzer
+}
+
+// NewDisableBinaryExpressionAnalyzer is a wrapper around the analyzer that disables binary expressions.
+func NewDisableBinaryExpressionAnalyzer(analyzer querysharding.Analyzer) *disableBinaryExpressionAnalyzer {
+	return &disableBinaryExpressionAnalyzer{analyzer: analyzer}
+}
+
+func (d *disableBinaryExpressionAnalyzer) Analyze(query string) (querysharding.QueryAnalysis, error) {
+	analysis, err := d.analyzer.Analyze(query)
+	if err != nil || !analysis.IsShardable() {
+		return analysis, err
+	}
+
+	expr, _ := cortexparser.ParseExpr(query)
+	isShardable := true
+	parser.Inspect(expr, func(node parser.Node, nodes []parser.Node) error {
+		switch n := node.(type) {
+		case *parser.BinaryExpr:
+			// No vector matching means one operand is not vector. Skip it.
+			if n.VectorMatching == nil {
+				return nil
+			}
+			// Vector matching ignore will add MetricNameLabel as sharding label.
+			// Mark this type of query not shardable.
+			if !n.VectorMatching.On {
+				isShardable = false
+				return stop
+			}
+		}
+		return nil
+	})
+	if !isShardable {
+		// Mark as not shardable.
+		return querysharding.QueryAnalysis{}, nil
+	}
+	return analysis, nil
 }

--- a/pkg/querysharding/util.go
+++ b/pkg/querysharding/util.go
@@ -7,6 +7,8 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
+
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 )
 
 const (
@@ -21,7 +23,7 @@ var (
 )
 
 func InjectShardingInfo(query string, shardInfo *storepb.ShardInfo) (string, error) {
-	expr, err := parser.ParseExpr(query)
+	expr, err := cortexparser.ParseExpr(query)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/querysharding/util_test.go
+++ b/pkg/querysharding/util_test.go
@@ -1,0 +1,145 @@
+package querysharding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos/pkg/querysharding"
+)
+
+func TestDisableBinaryExpressionAnalyzer_Analyze(t *testing.T) {
+	tests := []struct {
+		name            string
+		query           string
+		expectShardable bool
+		expectError     bool
+		description     string
+	}{
+		{
+			name:            "binary expression with vector matching on",
+			query:           `up{job="prometheus"} + on(instance) rate(cpu_usage[5m])`,
+			expectShardable: true,
+			expectError:     false,
+			description:     "Binary expression with 'on' matching should remain shardable",
+		},
+		{
+			name:            "binary expression without explicit vector matching",
+			query:           `up{job="prometheus"} + rate(cpu_usage[5m])`,
+			expectShardable: false,
+			expectError:     false,
+			description:     "No explicit vector matching means without. Not shardable.",
+		},
+		{
+			name:            "binary expression with vector matching ignoring",
+			query:           `up{job="prometheus"} + ignoring(instance) rate(cpu_usage[5m])`,
+			expectShardable: false,
+			expectError:     false,
+			description:     "Binary expression with 'ignoring' matching should not be shardable",
+		},
+		{
+			name:            "complex expression with binary expr using on",
+			query:           `sum(rate(http_requests_total[5m])) by (job) + on(job) avg(cpu_usage) by (job)`,
+			expectShardable: true,
+			expectError:     false,
+			description:     "Complex expression with 'on' matching should remain shardable",
+		},
+		{
+			name:            "complex expression with binary expr using ignoring",
+			query:           `sum(rate(http_requests_total[5m])) by (job) + ignoring(instance) avg(cpu_usage) by (job)`,
+			expectShardable: false,
+			expectError:     false,
+			description:     "Complex expression with 'ignoring' matching should not be shardable",
+		},
+		{
+			name:            "nested binary expressions with one ignoring",
+			query:           `(up + on(job) rate(cpu[5m])) * ignoring(instance) memory_usage`,
+			expectShardable: false,
+			expectError:     false,
+			description:     "Nested expressions with any 'ignoring' should not be shardable",
+		},
+		{
+			name:            "aggregation",
+			query:           `sum(rate(http_requests_total[5m])) by (job)`,
+			expectShardable: true,
+			expectError:     false,
+			description:     "Aggregations should remain shardable",
+		},
+		{
+			name:            "aggregation with binary expression and scalar",
+			query:           `sum(rate(http_requests_total[5m])) by (job) * 100`,
+			expectShardable: true,
+			expectError:     false,
+			description:     "Aggregations should remain shardable",
+		},
+		{
+			name:            "invalid query",
+			query:           "invalid{query",
+			expectShardable: false,
+			expectError:     true,
+			description:     "Invalid queries should return error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create the actual thanos analyzer
+			thanosAnalyzer := querysharding.NewQueryAnalyzer()
+
+			// Wrap it with our disable binary expression analyzer
+			analyzer := NewDisableBinaryExpressionAnalyzer(thanosAnalyzer)
+
+			// Test the wrapped analyzer
+			result, err := analyzer.Analyze(tt.query)
+
+			if tt.expectError {
+				require.Error(t, err, tt.description)
+				return
+			}
+
+			require.NoError(t, err, tt.description)
+			assert.Equal(t, tt.expectShardable, result.IsShardable(), tt.description)
+		})
+	}
+}
+
+func TestDisableBinaryExpressionAnalyzer_ComparedToOriginal(t *testing.T) {
+	// Test cases that verify the wrapper correctly modifies behavior
+	testCases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "ignoring expression should be disabled",
+			query: `up + ignoring(instance) rate(cpu[5m])`,
+		},
+		{
+			name:  "nested ignoring expression should be disabled",
+			query: `(sum(rate(http_requests_total[5m])) by (job)) + ignoring(instance) avg(cpu_usage) by (job)`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test with original analyzer
+			originalAnalyzer := querysharding.NewQueryAnalyzer()
+			originalResult, err := originalAnalyzer.Analyze(tc.query)
+			require.NoError(t, err)
+
+			// Test with wrapped analyzer
+			wrappedAnalyzer := NewDisableBinaryExpressionAnalyzer(originalAnalyzer)
+			wrappedResult, err := wrappedAnalyzer.Analyze(tc.query)
+			require.NoError(t, err)
+
+			// The wrapped analyzer should make previously shardable queries non-shardable
+			// if they contain binary expressions with ignoring
+			if originalResult.IsShardable() {
+				assert.False(t, wrappedResult.IsShardable(),
+					"Wrapped analyzer should disable sharding for queries with ignoring vector matching")
+			} else {
+				// If original wasn't shardable, wrapped shouldn't be either
+				assert.False(t, wrappedResult.IsShardable())
+			}
+		})
+	}
+}

--- a/pkg/ruler/compat.go
+++ b/pkg/ruler/compat.go
@@ -15,13 +15,13 @@ import (
 	"github.com/prometheus/prometheus/model/metadata"
 	"github.com/prometheus/prometheus/notifier"
 	"github.com/prometheus/prometheus/promql"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/rules"
 	"github.com/prometheus/prometheus/storage"
 	"github.com/weaveworks/common/httpgrpc"
 	"github.com/weaveworks/common/user"
 
 	"github.com/cortexproject/cortex/pkg/cortexpb"
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/querier"
 	"github.com/cortexproject/cortex/pkg/querier/stats"
 	"github.com/cortexproject/cortex/pkg/ring/client"
@@ -171,7 +171,7 @@ func EngineQueryFunc(engine promql.QueryEngine, frontendClient *frontendClient, 
 		// Enforce the max query length.
 		maxQueryLength := overrides.MaxQueryLength(userID)
 		if maxQueryLength > 0 {
-			expr, err := parser.ParseExpr(qs)
+			expr, err := cortexparser.ParseExpr(qs)
 			// If failed to parse expression, skip checking select range.
 			// Fail the query in the engine.
 			if err == nil {

--- a/pkg/util/promql/promql_test.go
+++ b/pkg/util/promql/promql_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/require"
+
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 )
 
 func TestFindNonOverlapQueryLength(t *testing.T) {
@@ -78,7 +79,7 @@ func TestFindNonOverlapQueryLength(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			expr, err := parser.ParseExpr(tc.query)
+			expr, err := cortexparser.ParseExpr(tc.query)
 			require.NoError(t, err)
 			duration := FindNonOverlapQueryLength(expr, 0, 0, time.Minute*5)
 			require.Equal(t, tc.expectedLength, duration)

--- a/pkg/util/time_test.go
+++ b/pkg/util/time_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
+	cortexparser "github.com/cortexproject/cortex/pkg/parser"
 	"github.com/cortexproject/cortex/pkg/util/test"
 )
 
@@ -178,7 +178,7 @@ func TestFindMinMaxTime(t *testing.T) {
 
 	for testName, testData := range tests {
 		t.Run(testName, func(t *testing.T) {
-			expr, _ := parser.ParseExpr(testData.query)
+			expr, _ := cortexparser.ParseExpr(testData.query)
 
 			url := "/query_range?query=" + testData.query +
 				"&start=" + strconv.FormatInt(testData.queryStartTime.Truncate(time.Minute).Unix(), 10) +


### PR DESCRIPTION
**What this PR does**:
Allow querier to execute from logical plans with PromQL engine fallback. Tested with querierAPI + query engine unit tests and new integration tests.

**Which issue(s) this PR fixes**:
Fixes 

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated - the order of entries should be `[CHANGE]`, `[FEATURE]`, `[ENHANCEMENT]`, `[BUGFIX]`
